### PR TITLE
specre: add status command

### DIFF
--- a/docs/specres/cli/INDEX.md
+++ b/docs/specres/cli/INDEX.md
@@ -5,3 +5,4 @@
 | [specre_new_scaffolds_a_new_specre](specre_new_scaffolds_a_new_specre.md) | stable | 2026-02-13 |
 | [specre_init_initializes_project_configuration](specre_init_initializes_project_configuration.md) | stable | 2026-02-13 |
 | [specre_index_generates_project_index](specre_index_generates_project_index.md) | stable | 2026-02-13 |
+| [specre_status_reports_project_health](specre_status_reports_project_health.md) | stable | 2026-02-13 |

--- a/docs/specres/cli/specre_status_reports_project_health.md
+++ b/docs/specres/cli/specre_status_reports_project_health.md
@@ -1,0 +1,112 @@
+---
+id: "01KHAN6JE712ZAKXPP97854PKJ"
+name: "specre_status_reports_project_health"
+status: "stable"
+last_verified: "2026-02-13"
+---
+
+## Related Files
+
+- `src/commands/status.rs`
+- `src/config.rs`
+- `tests/cli_status.rs` (Test)
+
+## Functional Overview
+
+`specre status` scans all specre files in the project and reports a summary of project health: counts by lifecycle status (draft, in-development, stable, deprecated) and a list of stable specres whose `last_verified` date is stale. It reads `specre.toml` to determine the specre directory.
+
+## Design Intent
+
+The status command gives developers and AI agents a quick health check of their specification base. By surfacing stale specres — those whose `last_verified` date exceeds a threshold — it encourages regular re-verification and prevents specification drift from going unnoticed.
+
+Staleness threshold defaults to 30 days but can be overridden via the `--threshold` option, allowing teams to set their own cadence.
+
+## Key Members
+
+- `threshold: u32` — number of days after which a stable specre's `last_verified` is considered stale (default: 30)
+- `StatusSummary` — aggregated counts: `draft`, `in_development`, `stable`, `deprecated`, `total`
+- `StaleEntry` — a stable specre whose `last_verified` is older than the threshold: contains `name`, `path`, `last_verified`, `days_since`
+
+## Scenarios
+
+### Basic invocation shows status summary
+
+1. User runs `specre status` in a project with `specre.toml` and several specre files in different statuses
+2. CLI reads `specre.toml` to determine `specre_dir`
+3. CLI scans all `.md` files under `specre_dir` recursively, parsing YAML front-matter
+4. CLI prints a summary table to stdout:
+   ```
+   Status Summary:
+     draft:          2
+     in-development: 1
+     stable:         5
+     deprecated:     0
+     total:          8
+   ```
+
+### Stale specres are flagged
+
+1. User runs `specre status` in a project where some stable specres have `last_verified` dates older than 30 days from today
+2. CLI prints the status summary (as above)
+3. CLI prints a stale specres section to stdout:
+   ```
+   Stale specres (last_verified > 30 days):
+     user_can_reset_password       docs/specres/auth/user_can_reset_password.md       (45 days)
+     cart_total_reflects_changes   docs/specres/cart/cart_total_reflects_changes.md    (62 days)
+   ```
+
+### No stale specres
+
+1. User runs `specre status` and all stable specres have `last_verified` within 30 days
+2. CLI prints the status summary
+3. No stale specres section is printed
+
+### Custom threshold via --threshold
+
+1. User runs `specre status --threshold 90`
+2. CLI uses 90 days as the staleness threshold instead of the default 30
+3. Only stable specres whose `last_verified` exceeds 90 days are flagged
+
+### Stable specres without last_verified are always flagged
+
+1. A stable specre has no `last_verified` field in its front-matter
+2. CLI treats it as stale regardless of the threshold
+3. The stale entry shows `(no last_verified)` instead of the day count
+
+### Invalid last_verified format is flagged as stale
+
+1. A stable specre has `last_verified: "yesterday"` (not YYYY-MM-DD format)
+2. CLI prints a warning to stderr: `Warning: invalid last_verified in <path>: "yesterday"`
+3. CLI treats it as stale, showing `(invalid last_verified)` instead of the day count
+
+### Impossible date in last_verified is flagged as stale
+
+1. A stable specre has `last_verified: "2026-02-30"` (valid format but non-existent date)
+2. CLI prints a warning to stderr: `Warning: invalid last_verified in <path>: "2026-02-30"`
+3. CLI treats it as stale, showing `(invalid last_verified)` instead of the day count
+
+### last_verified on non-stable specres is ignored
+
+1. A draft specre has `last_verified: "2026-01-01"` in its front-matter
+2. CLI counts it under `draft` in the status summary
+3. CLI does not include it in the stale specres section (stale detection applies only to stable specres)
+4. No warning is emitted — the field is simply ignored
+
+### Empty specre directory
+
+1. User runs `specre status` with a valid `specre.toml` but no specre files exist
+2. CLI prints the summary with all counts at 0
+3. No stale specres section is printed
+
+### specre.toml does not exist
+
+1. User runs `specre status` in a directory without `specre.toml`
+2. CLI exits with error: `Error: specre.toml not found. Run 'specre init' first.`
+
+## Failures / Exceptions
+
+- If `specre.toml` is missing, CLI exits with error: `Error: specre.toml not found. Run 'specre init' first.`
+- If a specre file has malformed front-matter (missing `---` delimiters or required fields), CLI prints a warning to stderr and skips that file
+- If `specre_dir` does not exist, CLI treats it as empty (all counts 0)
+- If a stable specre's `last_verified` is not a valid YYYY-MM-DD date (wrong format or impossible date), CLI prints a warning to stderr and treats it as stale with `(invalid last_verified)`
+- If a non-stable specre has `last_verified`, the field is silently ignored

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-13T04:43:07Z",
+  "generated_at": "2026-02-13T05:11:17Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -24,6 +24,14 @@
       "status": "stable",
       "domain": "cli",
       "path": "docs/specres/cli/specre_index_generates_project_index.md",
+      "last_verified": "2026-02-13"
+    },
+    {
+      "id": "01KHAN6JE712ZAKXPP97854PKJ",
+      "name": "specre_status_reports_project_health",
+      "status": "stable",
+      "domain": "cli",
+      "path": "docs/specres/cli/specre_status_reports_project_health.md",
       "last_verified": "2026-02-13"
     }
   ],

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,9 @@ pub enum Commands {
 
     /// Generate index.json and per-domain INDEX.md
     Index,
+
+    /// Report specre counts by status and flag stale last_verified dates
+    Status(StatusArgs),
 }
 
 #[derive(Args)]
@@ -32,6 +35,13 @@ pub struct InitArgs {
     /// Directories to scan for @specre markers (comma-separated)
     #[arg(long, default_value = "src", value_delimiter = ',')]
     pub source_dirs: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct StatusArgs {
+    /// Number of days after which a stable specre's last_verified is considered stale
+    #[arg(long, default_value_t = 30)]
+    pub threshold: u32,
 }
 
 #[derive(Args)]

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -97,7 +97,7 @@ fn scan_specre_files(dir: &Path, specre_dir_str: &str) -> Vec<SpecreEntry> {
     entries
 }
 
-fn collect_md_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
+pub fn collect_md_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
     let read_dir = match fs::read_dir(dir) {
         Ok(rd) => rd,
         Err(_) => return,
@@ -121,14 +121,14 @@ fn collect_md_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
     }
 }
 
-struct Frontmatter {
-    id: String,
-    name: String,
-    status: String,
-    last_verified: Option<String>,
+pub struct Frontmatter {
+    pub id: String,
+    pub name: String,
+    pub status: String,
+    pub last_verified: Option<String>,
 }
 
-fn parse_frontmatter(content: &str) -> Option<Frontmatter> {
+pub fn parse_frontmatter(content: &str) -> Option<Frontmatter> {
     let content = content.trim_start_matches('\u{feff}'); // BOM
     if !content.starts_with("---") {
         return None;
@@ -239,7 +239,7 @@ fn collect_all_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
     }
 }
 
-fn to_forward_slash(path: &Path) -> String {
+pub fn to_forward_slash(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod index;
 pub mod init;
 pub mod new;
+pub mod status;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,102 @@
+use crate::cli::StatusArgs;
+use crate::commands::index::{collect_md_files, parse_frontmatter, to_forward_slash};
+use crate::config;
+use chrono::{NaiveDate, Utc};
+use std::fs;
+use std::path::Path;
+
+struct StaleEntry {
+    name: String,
+    path: String,
+    reason: String,
+}
+
+pub fn execute(args: StatusArgs) -> Result<(), String> {
+    let config = config::load()?;
+    let specre_dir = Path::new(&config.specre_dir);
+
+    let today = Utc::now().date_naive();
+    let threshold = args.threshold;
+
+    let mut draft = 0u32;
+    let mut in_development = 0u32;
+    let mut stable = 0u32;
+    let mut deprecated = 0u32;
+    let mut stale_entries: Vec<StaleEntry> = Vec::new();
+
+    if specre_dir.exists() {
+        collect_md_files(specre_dir, &mut |path| {
+            let content = match fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Warning: failed to read '{}': {e}", path.display());
+                    return;
+                }
+            };
+            match parse_frontmatter(&content) {
+                Some(fm) => match fm.status.as_str() {
+                    "draft" => draft += 1,
+                    "in-development" => in_development += 1,
+                    "stable" => {
+                        stable += 1;
+                        let reason = match &fm.last_verified {
+                            None => Some("no last_verified".to_string()),
+                            Some(date_str) => match NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                            {
+                                Ok(date) => {
+                                    let days = (today - date).num_days();
+                                    if days > threshold as i64 {
+                                        Some(format!("{days} days"))
+                                    } else {
+                                        None
+                                    }
+                                }
+                                Err(_) => {
+                                    let rel_path = to_forward_slash(path);
+                                    eprintln!(
+                                        "Warning: invalid last_verified in {rel_path}: \"{date_str}\""
+                                    );
+                                    Some("invalid last_verified".to_string())
+                                }
+                            },
+                        };
+                        if let Some(reason) = reason {
+                            stale_entries.push(StaleEntry {
+                                name: fm.name,
+                                path: to_forward_slash(path),
+                                reason,
+                            });
+                        }
+                    }
+                    "deprecated" => deprecated += 1,
+                    _ => {}
+                },
+                None => {
+                    eprintln!(
+                        "Warning: skipping '{}' (malformed front-matter)",
+                        path.display()
+                    );
+                }
+            }
+        });
+    }
+
+    let total = draft + in_development + stable + deprecated;
+
+    println!("Status Summary:");
+    println!("  draft:          {draft}");
+    println!("  in-development: {in_development}");
+    println!("  stable:         {stable}");
+    println!("  deprecated:     {deprecated}");
+    println!("  total:          {total}");
+
+    if !stale_entries.is_empty() {
+        println!();
+        println!("Stale specres (last_verified > {threshold} days):");
+        for entry in &stale_entries {
+            println!("  {}  {}  ({})", entry.name, entry.path, entry.reason);
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
         Commands::Init(args) => commands::init::execute(args),
         Commands::New(args) => commands::new::execute(args),
         Commands::Index => commands::index::execute(),
+        Commands::Status(args) => commands::status::execute(args),
     };
 
     if let Err(e) = result {

--- a/tests/cli_status.rs
+++ b/tests/cli_status.rs
@@ -1,0 +1,362 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::TempDir;
+use chrono::{Days, Utc};
+use predicates::prelude::*;
+use std::fs;
+
+fn specre() -> assert_cmd::Command {
+    cargo_bin_cmd!("specre")
+}
+
+/// Helper: create specre.toml with given specre_dir
+fn write_config(dir: &std::path::Path, specre_dir: &str) {
+    let content = format!("specre_dir = \"{specre_dir}\"\nsource_dirs = [\"src\"]\n");
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
+/// Helper: create a specre .md file with front-matter
+fn write_specre(
+    dir: &std::path::Path,
+    rel_path: &str,
+    id: &str,
+    name: &str,
+    status: &str,
+    last_verified: Option<&str>,
+) {
+    let path = dir.join(rel_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut fm = format!("---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n");
+    if let Some(lv) = last_verified {
+        fm.push_str(&format!("last_verified: \"{lv}\"\n"));
+    }
+    fm.push_str("---\n\n## Related Files\n\n-\n");
+    fs::write(path, fm).unwrap();
+}
+
+fn today_str() -> String {
+    Utc::now().date_naive().format("%Y-%m-%d").to_string()
+}
+
+fn days_ago_str(days: u64) -> String {
+    Utc::now()
+        .date_naive()
+        .checked_sub_days(Days::new(days))
+        .unwrap()
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+// -- Scenario: Basic invocation shows status summary --
+
+#[test]
+fn status_shows_summary() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "draft",
+        None,
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_b.md",
+        "01BBBBBBBBBBBBBBBBBBBBBBBBBB",
+        "spec_b",
+        "draft",
+        None,
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_c.md",
+        "01CCCCCCCCCCCCCCCCCCCCCCCCCC",
+        "spec_c",
+        "in-development",
+        None,
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_d.md",
+        "01DDDDDDDDDDDDDDDDDDDDDDDD",
+        "spec_d",
+        "stable",
+        Some(&today_str()),
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_e.md",
+        "01EEEEEEEEEEEEEEEEEEEEEEEEEE",
+        "spec_e",
+        "deprecated",
+        None,
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Status Summary:")
+                .and(predicate::str::contains("draft:          2"))
+                .and(predicate::str::contains("in-development: 1"))
+                .and(predicate::str::contains("stable:         1"))
+                .and(predicate::str::contains("deprecated:     1"))
+                .and(predicate::str::contains("total:          5")),
+        );
+}
+
+// -- Scenario: Stale specres are flagged --
+
+#[test]
+fn status_flags_stale_specres() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/auth/user_can_reset_password.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "user_can_reset_password",
+        "stable",
+        Some(&days_ago_str(45)),
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Stale specres (last_verified > 30 days):")
+                .and(predicate::str::contains("user_can_reset_password"))
+                .and(predicate::str::contains("(45 days)")),
+        );
+}
+
+// -- Scenario: No stale specres --
+
+#[test]
+fn status_no_stale_section_when_all_fresh() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/fresh_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "fresh_spec",
+        "stable",
+        Some(&today_str()),
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Status Summary:")
+                .and(predicate::str::contains("Stale specres").not()),
+        );
+}
+
+// -- Scenario: Custom threshold via --threshold --
+
+#[test]
+fn status_custom_threshold() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    // 45 days ago — stale at default 30, but not stale at threshold 90
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some(&days_ago_str(45)),
+    );
+
+    specre()
+        .args(["status", "--threshold", "90"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Status Summary:")
+                .and(predicate::str::contains("Stale specres").not()),
+        );
+}
+
+#[test]
+fn status_custom_threshold_shows_in_header() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some(&days_ago_str(100)),
+    );
+
+    specre()
+        .args(["status", "--threshold", "90"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Stale specres (last_verified > 90 days):",
+        ));
+}
+
+// -- Scenario: Stable specres without last_verified are always flagged --
+
+#[test]
+fn status_stable_without_last_verified_is_stale() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/no_date_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "no_date_spec",
+        "stable",
+        None,
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("no_date_spec")
+                .and(predicate::str::contains("(no last_verified)")),
+        );
+}
+
+// -- Scenario: Invalid last_verified format is flagged as stale --
+
+#[test]
+fn status_invalid_last_verified_format() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/bad_date_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "bad_date_spec",
+        "stable",
+        Some("yesterday"),
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("bad_date_spec")
+                .and(predicate::str::contains("(invalid last_verified)")),
+        )
+        .stderr(predicate::str::contains(
+            "Warning: invalid last_verified in",
+        ).and(predicate::str::contains("\"yesterday\"")));
+}
+
+// -- Scenario: Impossible date in last_verified is flagged as stale --
+
+#[test]
+fn status_impossible_date_in_last_verified() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/impossible_date_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "impossible_date_spec",
+        "stable",
+        Some("2026-02-30"),
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("impossible_date_spec")
+                .and(predicate::str::contains("(invalid last_verified)")),
+        )
+        .stderr(predicate::str::contains(
+            "Warning: invalid last_verified in",
+        ).and(predicate::str::contains("\"2026-02-30\"")));
+}
+
+// -- Scenario: last_verified on non-stable specres is ignored --
+
+#[test]
+fn status_last_verified_on_non_stable_is_ignored() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    // Draft with a stale last_verified — should be counted as draft, not flagged
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/draft_with_date.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "draft_with_date",
+        "draft",
+        Some("2025-01-01"),
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("draft:          1")
+                .and(predicate::str::contains("Stale specres").not()),
+        );
+}
+
+// -- Scenario: Empty specre directory --
+
+#[test]
+fn status_empty_specre_directory() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("draft:          0")
+                .and(predicate::str::contains("in-development: 0"))
+                .and(predicate::str::contains("stable:         0"))
+                .and(predicate::str::contains("deprecated:     0"))
+                .and(predicate::str::contains("total:          0"))
+                .and(predicate::str::contains("Stale specres").not()),
+        );
+}
+
+// -- Scenario: specre.toml does not exist --
+
+#[test]
+fn status_errors_without_config() {
+    let tmp = TempDir::new().unwrap();
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "specre.toml not found. Run 'specre init' first.",
+        ));
+}


### PR DESCRIPTION
Report specre counts by lifecycle status (draft, in-development, stable, deprecated) and flag stable specres with stale or invalid last_verified dates. 

Supports --threshold to customize staleness detection (default 30 days).