### PR TITLE
docs: add cargo install instructions to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Most SDD tools (GitHub Spec Kit, Amazon Kiro, BMAD) treat specifications as larg
 
 ## Quick Start
 
+### Install via Cargo (Rust users)
+
+```bash
+cargo install specre
+```
+
+This installs the `specre` CLI from [crates.io](https://crates.io/crates/specre). Requires Rust 1.85+.
+
 ### As a Git Submodule
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `cargo install specre` section to Quick Start in README, now that v0.2.0 is published on crates.io

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm `cargo install specre` works from a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)