### PR TITLE
docs: add pre-built binary install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Most SDD tools (GitHub Spec Kit, Amazon Kiro, BMAD) treat specifications as larg
 
 ## Quick Start
 
+### Install Pre-built Binary
+
+```bash
+# Linux / macOS
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/yoshiakist/specre/releases/latest/download/specre-installer.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/yoshiakist/specre/releases/latest/download/specre-installer.ps1 | iex"
+```
+
 ### Install via Cargo (Rust users)
 
 ```bash


### PR DESCRIPTION
## Summary
- Add shell installer (curl) and PowerShell installer instructions to Quick Start
- Uses `/releases/latest/download/` URLs so no update needed on future releases

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm shell installer URL resolves (Linux/macOS)
- [x] Confirm PowerShell installer URL resolves (Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)