### PR TITLE
docs: separate roadmap into dedicated file, add v0.5 QA milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Each entry records a `@specre` marker found in the source tree:
 - **v0.2 — Traceability** ✅ `trace`, `orphans`, `tag`
 - **v0.3 — Agent Integration** — MCP server, `search`, `--json` output
 - **v0.4 — Drift Detection** — `drift`, `ci`, GitHub Actions template
+- **v0.5 — QA Support** — `impact`, `diff`, `export`
 
 ## Contributing
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -29,15 +29,34 @@ The MCP server wraps existing CLI logic as a thin layer, rather than reimplement
 |---------------|-----------------|
 | **Resources** | specre cards as `specre:///<ULID>` URIs. Agents can read individual specre cards on demand. |
 | **Tools** | `search`, `trace`, `orphans`, `status`, `index` — the same operations available via CLI, returning structured JSON. |
-| **Prompts** | SDD workflow templates (e.g., "implement a behavior from a specre card") for consistent agent-driven development. |
+| **Prompts** | SDD workflow templates (e.g., "implement a behavior from a specre card") and QA-oriented prompts (`review-qa`, `summarize-diff`) for consistent agent-driven development. |
 
 Transport: stdio (primary), with the option to add SSE/HTTP for remote use cases in the future.
+
+### MCP Prompts for QA
+
+The MCP server includes prompts designed for QA engineers, enabling them to leverage AI for specification-level quality assurance without reading implementation code.
+
+| Prompt | Purpose |
+|--------|---------|
+| `review-qa` | Analyze a specre card and suggest missing edge cases, boundary conditions, and Failures / Exceptions that may have been overlooked. |
+| `summarize-diff` | Semantically summarize changes between the previous stable version and the current in-development version of a specre, and suggest regression test scope. |
+
+These prompts keep specre engine-independent — the AI reasoning is performed by whichever LLM the agent is connected to, not by specre itself.
 
 ## v0.4 — Drift Detection
 
 - [ ] `specre drift` — Compare `last_verified` dates against git history of related files; flag specres where source has changed since last verification
 - [ ] `specre ci` — Exit with non-zero status if drift or orphans are detected (for CI integration)
 - [ ] GitHub Actions workflow template
+
+## v0.5 — QA Support
+
+Deterministic CLI commands that help QA engineers work directly with specre cards — no LLM required.
+
+- [ ] `specre impact <ULID>` — Transitive dependency and impact analysis. Traverse cross-references in Referenced Specifications sections and `@specre` markers to build a dependency graph, showing which specres and source files are affected by a change.
+- [ ] `specre diff [specre-path]` — Show how a specre card has changed since its last `stable` state, using git history. Complements `specre drift` (which detects *whether* something changed) by showing *what* changed.
+- [ ] `specre export [--format <fmt>]` — Convert Scenarios sections into structured test case formats (Markdown checklist, CSV) for import into test management tools. Eliminates the manual transcription of specifications into test cases.
 
 ## Future Considerations
 


### PR DESCRIPTION
## Summary

- Extract detailed roadmap from README into [docs/project/ROADMAP.md](docs/project/ROADMAP.md), keeping a concise 5-line summary in README with a link
- Update v0.3 to include MCP server with QA-oriented Prompts (`review-qa`, `summarize-diff`)
- Add v0.5 — QA Support milestone with deterministic CLI commands: `impact`, `diff`, `export`

## Design decisions

- **QA features split by determinism**: AI-powered QA features (edge case suggestion, semantic diff summary) are MCP Prompts in v0.3 — specre provides the "question template", the connected LLM does the reasoning. Deterministic QA features (`impact`, `diff`, `export`) are CLI commands in v0.5.
- **Roadmap separation**: README stays scannable for first-time visitors while ROADMAP.md carries full detail including MCP server design notes.

## Test plan

- [x] Verify README roadmap section renders correctly on GitHub
- [x] Verify ROADMAP.md link from README resolves correctly
- [x] Verify ROADMAP.md renders correctly (tables, checkboxes, links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)