### PR TITLE
feat: expand specre tag comment syntax to 80+ extensions

### DIFF
--- a/docs/specres/cli/INDEX.md
+++ b/docs/specres/cli/INDEX.md
@@ -8,5 +8,5 @@
 | [specre_status_reports_project_health](specre_status_reports_project_health.md) | stable | 2026-02-13 |
 | [specre_trace_resolves_bidirectional_references](specre_trace_resolves_bidirectional_references.md) | stable | 2026-02-13 |
 | [specre_orphans_detects_unlinked_specres_and_markers](specre_orphans_detects_unlinked_specres_and_markers.md) | stable | 2026-02-13 |
-| [specre_tag_inserts_marker_into_source_file](specre_tag_inserts_marker_into_source_file.md) | stable | 2026-02-13 |
+| [specre_tag_inserts_marker_into_source_file](specre_tag_inserts_marker_into_source_file.md) | stable | 2026-02-14 |
 | [user_can_set_language_config](user_can_set_language_config.md) | stable | 2026-02-14 |

--- a/docs/specres/cli/specre_tag_inserts_marker_into_source_file.md
+++ b/docs/specres/cli/specre_tag_inserts_marker_into_source_file.md
@@ -2,7 +2,7 @@
 id: "01KHB48EYB9686YYQMYFYQ5R1Z"
 name: "specre_tag_inserts_marker_into_source_file"
 status: "stable"
-last_verified: "2026-02-13"
+last_verified: "2026-02-14"
 ---
 
 ## Related Files
@@ -38,12 +38,82 @@ Inserting at line 1 is the simplest unambiguous strategy. Developers can reposit
 
 ### Comment syntax varies by language
 
-1. For `.rs`, `.js`, `.ts`, `.java`, `.c`, `.cpp`, `.cs`, `.go`, `.swift` files: `// @specre <ULID>`
-2. For `.rb`, `.py`, `.sh`, `.yaml`, `.yml`, `.toml` files: `# @specre <ULID>`
-3. For `.css`, `.scss` files: `/* @specre <ULID> */`
-4. For `.html`, `.xml`, `.svg` files: `<!-- @specre <ULID> -->`
-5. For `.sql` files: `-- @specre <ULID>`
-6. For unrecognized extensions: `// @specre <ULID>` (default)
+The command supports the following file extensions, organized by domain:
+
+**`// @specre <ULID>` — C-family, JVM, modern languages, shaders:**
+
+- General: `.rs`, `.js`, `.ts`, `.jsx`, `.tsx`, `.java`, `.c`, `.cpp`, `.h`, `.hpp`, `.cs`, `.go`, `.swift`, `.kt`, `.kts`, `.scala`, `.groovy`, `.gradle`, `.dart`, `.php`, `.zig`
+- Data / schema: `.proto`, `.prisma`, `.jsonc`
+- Unity shaders: `.shader`, `.hlsl`, `.cginc`, `.compute`
+- Unreal Engine shaders: `.usf`, `.ush`
+- Godot shaders: `.gdshader`
+- Graphics shaders: `.glsl`, `.vert`, `.frag`, `.geom`, `.wgsl`
+
+**`# @specre <ULID>` — scripting, config, data:**
+
+- General: `.rb`, `.py`, `.sh`, `.bash`, `.zsh`, `.yaml`, `.yml`, `.toml`
+- Godot: `.gd` (GDScript)
+- Additional languages: `.pl`, `.pm` (Perl), `.r`, `.R` (R), `.ex`, `.exs` (Elixir), `.nim`
+- Shell: `.ps1`, `.psm1`, `.psd1` (PowerShell), `.fish`, `.nix`
+- Infrastructure: `.tf`, `.tfvars`, `.hcl` (Terraform / HCL), `.cmake`, `.mk`
+- Config: `.env`, `.conf`, `.properties`
+- Query / schema: `.graphql`, `.gql`
+- Unity serialized (YAML): `.unity`, `.prefab`, `.asset`, `.mat`, `.meta`
+
+**`/* @specre <ULID> */` — stylesheets:**
+
+- `.css`, `.scss`, `.sass`, `.less`
+- Unity: `.uss` (UI StyleSheet)
+
+**`<!-- @specre <ULID> -->` — markup, SFC:**
+
+- General: `.html`, `.htm`, `.xml`, `.svg`
+- Frontend frameworks: `.vue`, `.svelte`, `.astro`
+- Unity: `.uxml` (UI XML)
+- XML transforms: `.xsl`, `.xslt`
+
+**`-- @specre <ULID>` — SQL, Lua, Haskell:**
+
+- `.sql`, `.lua`, `.hs`
+
+**`; @specre <ULID>` — Godot data, INI:**
+
+- Godot: `.tscn` (scene), `.tres` (resource), `.godot` (project)
+- Config: `.ini`, `.cfg`
+
+**`{# @specre <ULID> #}` — Jinja / Twig templates:**
+
+- `.j2`, `.jinja`, `.jinja2` (Jinja2 — Django, Flask, Ansible)
+- `.twig` (Twig — Symfony)
+
+**`<%# @specre <ULID> %>` — embedded templates:**
+
+- `.erb` (ERB — Rails)
+- `.ejs` (EJS — Express)
+
+**`{{!-- @specre <ULID> --}}` — Handlebars:**
+
+- `.hbs`, `.handlebars`
+
+**`@* @specre <ULID> *@` — Razor:**
+
+- `.cshtml` (ASP.NET Razor)
+
+**`//- @specre <ULID>` — Pug / Jade:**
+
+- `.pug`, `.jade`
+
+**`-# @specre <ULID>` — Haml:**
+
+- `.haml`
+
+**Unsupported extensions:** The command refuses to insert a marker and exits with an error. No fallback.
+
+### Unsupported file extension
+
+1. User runs `specre tag <ULID> data/config.xyz` where `.xyz` is not in the supported list
+2. CLI does not modify the file
+3. CLI exits with error: `Error: unsupported file extension '.xyz' — comment syntax is unknown`
 
 ### Marker already exists in file
 
@@ -84,4 +154,5 @@ Inserting at line 1 is the simplest unambiguous strategy. Developers can reposit
 - If the target file does not exist, CLI exits with error: `Error: file not found: <path>`
 - If the target path is a directory, CLI exits with error: `Error: '<path>' is a directory, not a file`
 - If ULID format is invalid, CLI exits with error before any file operations
+- If the file extension is not in the supported list, CLI exits with error: `Error: unsupported file extension '.<ext>' — comment syntax is unknown`
 - If the filesystem is read-only or permissions are insufficient, CLI exits with the OS-level error message

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-14T07:10:07Z",
+  "generated_at": "2026-02-14T11:38:52Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -56,7 +56,7 @@
       "status": "stable",
       "domain": "cli",
       "path": "docs/specres/cli/specre_tag_inserts_marker_into_source_file.md",
-      "last_verified": "2026-02-13"
+      "last_verified": "2026-02-14"
     },
     {
       "id": "01KHDF9WHR5HFM4RQCF6HS3KCC",

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -7,21 +7,53 @@ fn is_valid_ulid(s: &str) -> bool {
     s.len() == 26 && s.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
 }
 
-fn comment_syntax(ext: &str) -> (&'static str, &'static str) {
+fn comment_syntax(ext: &str) -> Option<(&'static str, &'static str)> {
     match ext {
-        // // style
+        // // style — C-family, JVM, modern languages, shaders
         "rs" | "js" | "ts" | "jsx" | "tsx" | "java" | "c" | "cpp" | "h" | "hpp" | "cs" | "go"
-        | "swift" => ("// ", ""),
-        // # style
-        "rb" | "py" | "sh" | "bash" | "zsh" | "yaml" | "yml" | "toml" => ("# ", ""),
-        // /* */ style
-        "css" | "scss" | "sass" | "less" => ("/* ", " */"),
-        // <!-- --> style
-        "html" | "htm" | "xml" | "svg" => ("<!-- ", " -->"),
-        // -- style
-        "sql" => ("-- ", ""),
-        // default
-        _ => ("// ", ""),
+        | "swift" | "kt" | "kts" | "scala" | "groovy" | "gradle" | "dart" | "php" | "zig"
+        | "proto" | "prisma" | "jsonc"
+        | "shader" | "hlsl" | "cginc" | "compute"
+        | "usf" | "ush"
+        | "gdshader"
+        | "glsl" | "vert" | "frag" | "geom" | "wgsl" => Some(("// ", "")),
+        // # style — scripting, config, data
+        "rb" | "py" | "sh" | "bash" | "zsh" | "yaml" | "yml" | "toml"
+        | "gd"
+        | "pl" | "pm" | "r" | "R" | "ex" | "exs" | "nim"
+        | "ps1" | "psm1" | "psd1" | "fish" | "nix"
+        | "tf" | "tfvars" | "hcl" | "cmake" | "mk"
+        | "env" | "conf" | "properties"
+        | "graphql" | "gql"
+        | "unity" | "prefab" | "asset" | "mat" | "meta" => Some(("# ", "")),
+        // /* */ style — stylesheets
+        "css" | "scss" | "sass" | "less"
+        | "uss" => Some(("/* ", " */")),
+        // <!-- --> style — markup, SFC
+        "html" | "htm" | "xml" | "svg"
+        | "vue" | "svelte" | "astro"
+        | "uxml"
+        | "xsl" | "xslt" => Some(("<!-- ", " -->")),
+        // -- style — SQL, Lua, Haskell
+        "sql" | "lua" | "hs" => Some(("-- ", "")),
+        // ; style — Godot data, INI
+        "tscn" | "tres" | "godot"
+        | "ini" | "cfg" => Some(("; ", "")),
+        // {# #} style — Jinja / Twig templates
+        "j2" | "jinja" | "jinja2"
+        | "twig" => Some(("{# ", " #}")),
+        // <%# %> style — embedded templates
+        "erb" | "ejs" => Some(("<%# ", " %>")),
+        // {{!-- --}} style — Handlebars
+        "hbs" | "handlebars" => Some(("{{!-- ", " --}}")),
+        // @* *@ style — Razor
+        "cshtml" => Some(("@* ", " *@")),
+        // //- style — Pug / Jade
+        "pug" | "jade" => Some(("//- ", "")),
+        // -# style — Haml
+        "haml" => Some(("-# ", "")),
+        // unsupported
+        _ => None,
     }
 }
 
@@ -67,7 +99,12 @@ pub fn execute(args: TagArgs) -> Result<(), String> {
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
-    let (prefix, suffix) = comment_syntax(ext);
+    let (prefix, suffix) = comment_syntax(ext).ok_or_else(|| {
+        format!(
+            "unsupported file extension '.{}' — comment syntax is unknown",
+            ext
+        )
+    })?;
 
     let marker_line = format!("{prefix}@specre {}{suffix}\n", args.ulid);
     let new_content = format!("{marker_line}{content}");

--- a/tests/cli_tag.rs
+++ b/tests/cli_tag.rs
@@ -115,7 +115,7 @@ fn tag_uses_dash_dash_comment_for_sql() {
 }
 
 #[test]
-fn tag_uses_slash_slash_for_unknown_extension() {
+fn tag_rejects_unsupported_extension() {
     let tmp = TempDir::new().unwrap();
     write_source(tmp.path(), "src/file.xyz", "data\n");
 
@@ -123,10 +123,14 @@ fn tag_uses_slash_slash_for_unknown_extension() {
         .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "src/file.xyz"])
         .current_dir(tmp.path())
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains(
+            "unsupported file extension '.xyz'",
+        ));
 
+    // File must not be modified
     let content = fs::read_to_string(tmp.path().join("src/file.xyz")).unwrap();
-    assert!(content.starts_with("// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+    assert_eq!(content, "data\n");
 }
 
 // -- Scenario: Marker already exists in file --
@@ -275,4 +279,364 @@ fn tag_uses_hash_comment_for_yaml() {
 
     let content = fs::read_to_string(tmp.path().join("config/settings.yml")).unwrap();
     assert!(content.starts_with("# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Godot GDScript uses # --
+
+#[test]
+fn tag_uses_hash_comment_for_gdscript() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "src/player.gd", "extends Node2D\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "src/player.gd"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("src/player.gd")).unwrap();
+    assert!(content.starts_with("# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Godot scene file uses ; --
+
+#[test]
+fn tag_uses_semicolon_comment_for_godot_tscn() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "scenes/main.tscn", "[gd_scene format=3]\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "scenes/main.tscn"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("scenes/main.tscn")).unwrap();
+    assert!(content.starts_with("; @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Godot resource file uses ; --
+
+#[test]
+fn tag_uses_semicolon_comment_for_godot_tres() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "resources/data.tres", "[gd_resource format=3]\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "resources/data.tres"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("resources/data.tres")).unwrap();
+    assert!(content.starts_with("; @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: INI file uses ; --
+
+#[test]
+fn tag_uses_semicolon_comment_for_ini() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "config/settings.ini", "[section]\nkey=value\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "config/settings.ini"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("config/settings.ini")).unwrap();
+    assert!(content.starts_with("; @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Lua uses -- --
+
+#[test]
+fn tag_uses_dash_dash_comment_for_lua() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "scripts/init.lua", "print('hello')\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "scripts/init.lua"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("scripts/init.lua")).unwrap();
+    assert!(content.starts_with("-- @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Vue SFC uses <!-- --> --
+
+#[test]
+fn tag_uses_html_comment_for_vue() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "src/App.vue", "<template></template>\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "src/App.vue"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("src/App.vue")).unwrap();
+    assert!(content.starts_with("<!-- @specre 01AAAAAAAAAAAAAAAAAAAAAAAA -->\n"));
+}
+
+// -- Scenario: Svelte uses <!-- --> --
+
+#[test]
+fn tag_uses_html_comment_for_svelte() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "src/App.svelte", "<script></script>\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "src/App.svelte"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("src/App.svelte")).unwrap();
+    assert!(content.starts_with("<!-- @specre 01AAAAAAAAAAAAAAAAAAAAAAAA -->\n"));
+}
+
+// -- Scenario: Jinja2 template uses {# #} --
+
+#[test]
+fn tag_uses_jinja_comment_for_j2() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "templates/base.j2", "{{ content }}\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "templates/base.j2"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("templates/base.j2")).unwrap();
+    assert!(content.starts_with("{# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA #}\n"));
+}
+
+// -- Scenario: Twig template uses {# #} --
+
+#[test]
+fn tag_uses_jinja_comment_for_twig() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "templates/base.twig", "{{ content }}\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "templates/base.twig"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("templates/base.twig")).unwrap();
+    assert!(content.starts_with("{# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA #}\n"));
+}
+
+// -- Scenario: ERB template uses <%# %> --
+
+#[test]
+fn tag_uses_erb_comment_for_erb() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "views/index.erb", "<%= @title %>\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "views/index.erb"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("views/index.erb")).unwrap();
+    assert!(content.starts_with("<%# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA %>\n"));
+}
+
+// -- Scenario: EJS template uses <%# %> --
+
+#[test]
+fn tag_uses_erb_comment_for_ejs() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "views/index.ejs", "<%= title %>\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "views/index.ejs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("views/index.ejs")).unwrap();
+    assert!(content.starts_with("<%# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA %>\n"));
+}
+
+// -- Scenario: Handlebars uses {{!-- --}} --
+
+#[test]
+fn tag_uses_handlebars_comment_for_hbs() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "views/index.hbs", "{{content}}\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "views/index.hbs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("views/index.hbs")).unwrap();
+    assert!(content.starts_with("{{!-- @specre 01AAAAAAAAAAAAAAAAAAAAAAAA --}}\n"));
+}
+
+// -- Scenario: Razor uses @* *@ --
+
+#[test]
+fn tag_uses_razor_comment_for_cshtml() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "Views/Index.cshtml", "@model string\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "Views/Index.cshtml"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("Views/Index.cshtml")).unwrap();
+    assert!(content.starts_with("@* @specre 01AAAAAAAAAAAAAAAAAAAAAAAA *@\n"));
+}
+
+// -- Scenario: Pug uses //- --
+
+#[test]
+fn tag_uses_pug_comment_for_pug() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "views/index.pug", "h1 Hello\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "views/index.pug"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("views/index.pug")).unwrap();
+    assert!(content.starts_with("//- @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Haml uses -# --
+
+#[test]
+fn tag_uses_haml_comment_for_haml() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "views/index.haml", "%h1 Hello\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "views/index.haml"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("views/index.haml")).unwrap();
+    assert!(content.starts_with("-# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Unity shader uses // --
+
+#[test]
+fn tag_uses_slash_slash_for_unity_shader() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "Shaders/Custom.shader", "Shader \"Custom\" {}\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "Shaders/Custom.shader"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("Shaders/Custom.shader")).unwrap();
+    assert!(content.starts_with("// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Unity meta (YAML) uses # --
+
+#[test]
+fn tag_uses_hash_comment_for_unity_meta() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "Assets/Script.cs.meta", "guid: abc123\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "Assets/Script.cs.meta"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("Assets/Script.cs.meta")).unwrap();
+    assert!(content.starts_with("# @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Unity USS uses /* */ --
+
+#[test]
+fn tag_uses_block_comment_for_unity_uss() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "UI/style.uss", ".label { color: white; }\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "UI/style.uss"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("UI/style.uss")).unwrap();
+    assert!(content.starts_with("/* @specre 01AAAAAAAAAAAAAAAAAAAAAAAA */\n"));
+}
+
+// -- Scenario: Godot shader uses // --
+
+#[test]
+fn tag_uses_slash_slash_for_gdshader() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "shaders/effect.gdshader", "shader_type canvas_item;\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "shaders/effect.gdshader"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("shaders/effect.gdshader")).unwrap();
+    assert!(content.starts_with("// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: PHP uses // --
+
+#[test]
+fn tag_uses_slash_slash_for_php() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "src/index.php", "<?php echo 'hi'; ?>\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "src/index.php"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(tmp.path().join("src/index.php")).unwrap();
+    assert!(content.starts_with("// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n"));
+}
+
+// -- Scenario: Unsupported extension is rejected --
+
+#[test]
+fn tag_unsupported_extension_does_not_modify_file() {
+    let tmp = TempDir::new().unwrap();
+    write_source(tmp.path(), "data/file.bin", "\x00\x01\x02\n");
+
+    specre()
+        .args(["tag", "01AAAAAAAAAAAAAAAAAAAAAAAA", "data/file.bin"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unsupported file extension '.bin'",
+        ));
+
+    let content = fs::read_to_string(tmp.path().join("data/file.bin")).unwrap();
+    assert_eq!(content, "\x00\x01\x02\n");
 }


### PR DESCRIPTION
## Summary

- Expanded `specre tag` comment syntax support from 5 styles / 25 extensions to **12 styles / 80+ extensions**
- Added 7 new comment styles: `;` (Godot/INI), `{# #}` (Jinja/Twig), `<%# %>` (ERB/EJS), `{{!-- --}}` (Handlebars), `@* *@` (Razor), `//-` (Pug), `-#` (Haml)
- Game engines: Unity (shaders, YAML serialized, USS, UXML), Unreal Engine (shaders), Godot (.gd=`#`, .tscn/tres=`;`, .gdshader=`//`)
- Frontend SFC: Vue, Svelte, Astro → `<!-- -->`
- **Breaking change**: Unknown file extensions now error instead of silently falling back to `//`, preventing accidental file corruption

## Test plan

- [x] All 36 tag integration tests pass (22 new tests added)
- [x] All 99 project-wide tests pass with no regressions
- [x] Verified: unsupported extensions produce clear error message and do not modify files
- [x] Specre card updated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)