### PR TITLE
chore: bump version to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "specre"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specre"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "Atomic, living specification cards for AI-agent-friendly development"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from v0.2.2 to v0.2.3

### Changes included in this release
- Expanded `specre tag` comment syntax support (5 → 12 styles, 25 → 80+ extensions)
- Added game engine support (Unity, Unreal Engine, Godot)
- Added web/frontend framework template support (Jinja2, Twig, ERB, EJS, Handlebars, Razor, Pug, Haml)
- Unsupported file extensions now error instead of silently falling back to `//`

🤖 Generated with [Claude Code](https://claude.com/claude-code)