### PR TITLE
refactor: deduplicate is_valid_ulid into ulid::is_valid

### DIFF
--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -1,13 +1,8 @@
 // @specre 01KHB48EYB9686YYQMYFYQ5R1Z
 use crate::cli::TagArgs;
+use crate::ulid;
 use std::fs;
 use std::path::Path;
-
-fn is_valid_ulid(s: &str) -> bool {
-    s.len() == 26
-        && s.chars()
-            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
-}
 
 fn comment_syntax(ext: &str) -> Option<(&'static str, &'static str)> {
     match ext {
@@ -53,7 +48,7 @@ fn to_forward_slash(s: &str) -> String {
 }
 
 pub fn execute(args: TagArgs) -> Result<(), String> {
-    if !is_valid_ulid(&args.ulid) {
+    if !ulid::is_valid(&args.ulid) {
         return Err(
             "invalid ULID format. Expected 26 uppercase alphanumeric characters.".to_string(),
         );

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -4,18 +4,13 @@ use crate::commands::index::{
     collect_all_files, collect_md_files, extract_marker_ulid, parse_frontmatter, to_forward_slash,
 };
 use crate::config;
+use crate::ulid;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-fn is_valid_ulid(s: &str) -> bool {
-    s.len() == 26
-        && s.chars()
-            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
-}
-
 pub fn execute(args: TraceArgs) -> Result<(), String> {
-    if is_valid_ulid(&args.query) {
+    if ulid::is_valid(&args.query) {
         trace_by_ulid(&args.query)
     } else {
         trace_by_file(&args.query)

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -1,6 +1,12 @@
 // @specre 01JMBJK7QRVX3N4P5G6H8W9Y0Z
 use ulid::Ulid;
 
+pub fn is_valid(s: &str) -> bool {
+    s.len() == 26
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+}
+
 pub fn generate() -> String {
     Ulid::new().to_string()
 }


### PR DESCRIPTION
Move the duplicated ULID validation function from trace.rs and tag.rs into the shared ulid module as ulid::is_valid.

https://claude.ai/code/session_01WKcBjz9kFm1FVbhnvvd2gd