### PR TITLE
Add pronunciation guide for specre in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Atomic, living specification cards for AI-agent-friendly development.**
 
-specre is a minimal specification format and toolkit for Spec-Driven Development (SDD). Each specre is a single Markdown file describing exactly one behavior, with machine-readable front-matter for lifecycle tracking and agent navigation.
+specre ( /spékré/ ) is a minimal specification format and toolkit for Spec-Driven Development (SDD). Each specre is a single Markdown file describing exactly one behavior, with machine-readable front-matter for lifecycle tracking and agent navigation.
 
 ## The Problem
 


### PR DESCRIPTION
Add inline IPA notation ( /spékré/ ) to clarify the intended
pronunciation, inspired by Latin "crescere".

https://claude.ai/code/session_015akvM8AZU2MJpNJ6fszMq1