### PR TITLE
feat: add `specre coverage` command

### DIFF
--- a/docs/specres/cli/INDEX.md
+++ b/docs/specres/cli/INDEX.md
@@ -11,3 +11,4 @@
 | [specre_tag_inserts_marker_into_source_file](specre_tag_inserts_marker_into_source_file.md) | stable | 2026-02-14 |
 | [user_can_set_language_config](user_can_set_language_config.md) | stable | 2026-02-14 |
 | [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-15 |
+| [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-15 |

--- a/docs/specres/cli/specre_coverage_reports_source_file_tagging.md
+++ b/docs/specres/cli/specre_coverage_reports_source_file_tagging.md
@@ -1,0 +1,120 @@
+---
+id: "01KHFEA9QVV4A127VCRJY97A68"
+name: "specre_coverage_reports_source_file_tagging"
+status: "stable"
+last_verified: "2026-02-15"
+---
+
+## Related Files
+
+- `src/commands/coverage.rs`
+- `src/commands/index.rs` (reuses scanning helpers)
+- `src/config.rs`
+- `tests/cli_coverage.rs` (Test)
+
+## Functional Overview
+
+`specre coverage` reports what percentage of source files are linked to specre cards via `@specre` tags. It scans all files in the configured `source_dirs`, counts how many contain at least one `@specre` marker, and outputs the coverage ratio. The command respects `target_extensions` from `specre.toml` and also accepts a `--ext` flag to override the filter for a single invocation. This gives developers and AI agents a quick measure of how well-traced the codebase is.
+
+## Design Intent
+
+Coverage is a key metric for assessing traceability health. If most source files lack `@specre` markers, the bidirectional traceability system is incomplete and agents cannot rely on specre cards as a comprehensive description of the codebase. By surfacing this as a single number, the coverage command enables CI gates, agent preflight checks (via `health-check`), and developer awareness.
+
+## Key Members
+
+- `CoverageResult` — public struct returned by `compute_coverage()`, containing `total: usize`, `tagged: usize`, and `uncovered: Vec<String>`. This struct is the reusable unit: `execute()` formats it for human output, and future commands (e.g., `health-check`) can call `compute_coverage()` directly to obtain the same data without parsing CLI output.
+- **Total files:** the number of files found in `source_dirs` (filtered by `target_extensions` or `--ext` if specified)
+- **Tagged files:** the subset of total files that contain at least one `@specre <ULID>` marker
+- **Coverage percentage:** `tagged / total * 100`, displayed as a percentage with one decimal place. Derived from `CoverageResult` fields at display time.
+- `--ext` flag: comma-separated list of file extensions to filter by, overriding `target_extensions` from `specre.toml` for this invocation
+
+## Scenarios
+
+### Basic coverage report
+
+1. User runs `specre coverage` in a project with 4 source files, 3 of which contain `@specre` markers
+2. CLI prints:
+   ```
+   Coverage: 3/4 files (75.0%)
+   ```
+3. CLI exits with exit code 0
+
+### Full coverage
+
+1. User runs `specre coverage` in a project where all source files contain `@specre` markers
+2. CLI prints:
+   ```
+   Coverage: 2/2 files (100.0%)
+   ```
+3. CLI exits with exit code 0
+
+### No source files found
+
+1. User runs `specre coverage` in a project where `source_dirs` exist but contain no files (or no files matching the extension filter)
+2. CLI prints:
+   ```
+   Coverage: 0/0 files (N/A)
+   ```
+3. CLI exits with exit code 0
+
+### Zero coverage
+
+1. User runs `specre coverage` in a project where source files exist but none contain `@specre` markers
+2. CLI prints:
+   ```
+   Coverage: 0/3 files (0.0%)
+   ```
+3. CLI exits with exit code 0
+
+### Extension filtering via --ext flag
+
+1. User runs `specre coverage --ext rs` in a project with `.rs` and `.ts` files
+2. Only `.rs` files are counted in the denominator and numerator
+3. CLI prints the coverage report reflecting only the filtered files
+
+### Extension filtering via specre.toml target_extensions
+
+1. User configures `target_extensions = ["rs"]` in `specre.toml`
+2. User runs `specre coverage` (without `--ext`)
+3. Only `.rs` files are counted
+4. CLI prints the coverage report reflecting only the filtered files
+
+### --ext flag overrides specre.toml target_extensions
+
+1. User configures `target_extensions = ["rs"]` in `specre.toml`
+2. User runs `specre coverage --ext ts`
+3. Only `.ts` files are counted, ignoring the `target_extensions` config
+
+### Uncovered files are listed
+
+1. User runs `specre coverage` in a project with uncovered files
+2. After the summary line, CLI prints uncovered files:
+   ```
+   Coverage: 1/3 files (33.3%)
+
+   Uncovered files:
+     src/bar.rs
+     src/baz.rs
+   ```
+3. Uncovered file paths use forward slashes on all platforms and are sorted alphabetically
+
+### Paths use forward slashes
+
+1. On all platforms, output paths use forward slashes (`/`), not backslashes
+
+### specre.toml does not exist
+
+1. User runs `specre coverage` in a directory without `specre.toml`
+2. CLI exits with error: `Error: specre.toml not found. Run 'specre init' first.`
+
+### source_dirs directory does not exist
+
+1. User runs `specre coverage` where a `source_dirs` entry does not exist
+2. CLI skips that directory silently and counts only files from directories that exist
+
+## Failures / Exceptions
+
+- If `specre.toml` is missing, CLI exits with error: `Error: specre.toml not found. Run 'specre init' first.`
+- If a `source_dirs` entry does not exist, CLI skips it silently
+- Unreadable files are skipped silently (no warning to stderr)
+- Markers inside string literals are excluded (same logic as `extract_marker_ulid`)

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-15T01:12:09Z",
+  "generated_at": "2026-02-15T01:31:24Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -73,9 +73,22 @@
       "domain": "cli",
       "path": "docs/specres/cli/user_can_set_target_extensions.md",
       "last_verified": "2026-02-15"
+    },
+    {
+      "id": "01KHFEA9QVV4A127VCRJY97A68",
+      "name": "specre_coverage_reports_source_file_tagging",
+      "status": "stable",
+      "domain": "cli",
+      "path": "docs/specres/cli/specre_coverage_reports_source_file_tagging.md",
+      "last_verified": "2026-02-15"
     }
   ],
   "source_refs": [
+    {
+      "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
+      "file": "src/commands/coverage.rs",
+      "line": 1
+    },
     {
       "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
       "file": "src/commands/index.rs",
@@ -194,6 +207,11 @@
     {
       "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
       "file": "src/ulid.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
+      "file": "tests/cli_coverage.rs",
       "line": 1
     },
     {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,9 @@ pub enum Commands {
 
     /// Insert a @specre marker into a source file
     Tag(TagArgs),
+
+    /// Report the percentage of source files covered by @specre tags
+    Coverage(CoverageArgs),
 }
 
 #[derive(Args)]
@@ -74,6 +77,13 @@ pub struct TagArgs {
 
     /// Path to the source file where the marker will be inserted
     pub file: String,
+}
+
+#[derive(Args)]
+pub struct CoverageArgs {
+    /// Target file extensions to filter by (comma-separated, e.g., "rs,ts")
+    #[arg(long, value_delimiter = ',')]
+    pub ext: Option<Vec<String>>,
 }
 
 #[derive(Args)]

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -1,0 +1,81 @@
+// @specre 01KHFEA9QVV4A127VCRJY97A68
+use crate::cli::CoverageArgs;
+use crate::commands::index::{collect_all_files, extract_marker_ulid, to_forward_slash};
+use crate::config;
+use std::fs;
+use std::path::Path;
+
+pub struct CoverageResult {
+    pub total: usize,
+    pub tagged: usize,
+    pub uncovered: Vec<String>,
+}
+
+pub fn compute_coverage(
+    source_dirs: &[String],
+    target_extensions: Option<&[String]>,
+) -> CoverageResult {
+    let mut total = 0usize;
+    let mut tagged = 0usize;
+    let mut uncovered = Vec::new();
+
+    for dir_str in source_dirs {
+        let dir = Path::new(dir_str);
+        if !dir.exists() {
+            continue;
+        }
+        collect_all_files(dir, target_extensions, &mut |path| {
+            total += 1;
+            let content = match fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => {
+                    uncovered.push(to_forward_slash(path));
+                    return;
+                }
+            };
+            let has_marker = content
+                .lines()
+                .any(|line| extract_marker_ulid(line).is_some());
+            if has_marker {
+                tagged += 1;
+            } else {
+                uncovered.push(to_forward_slash(path));
+            }
+        });
+    }
+
+    uncovered.sort();
+
+    CoverageResult {
+        total,
+        tagged,
+        uncovered,
+    }
+}
+
+pub fn execute(args: CoverageArgs) -> Result<(), String> {
+    let config = config::load()?;
+
+    let extensions = args
+        .ext
+        .or(config.target_extensions);
+
+    let result = compute_coverage(&config.source_dirs, extensions.as_deref());
+
+    if result.total == 0 {
+        println!("Coverage: 0/0 files (N/A)");
+    } else {
+        let pct = result.tagged as f64 / result.total as f64 * 100.0;
+        println!("Coverage: {}/{} files ({:.1}%)", result.tagged, result.total, pct);
+    }
+
+    if !result.uncovered.is_empty() {
+        println!();
+        println!("Uncovered files:");
+        for path in &result.uncovered {
+            println!("  {path}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod coverage;
 pub mod index;
 pub mod init;
 pub mod new;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
         Commands::Trace(args) => commands::trace::execute(args),
         Commands::Orphans => commands::orphans::execute(),
         Commands::Tag(args) => commands::tag::execute(args),
+        Commands::Coverage(args) => commands::coverage::execute(args),
     };
 
     if let Err(e) = result {

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -1,0 +1,325 @@
+// @specre 01KHFEA9QVV4A127VCRJY97A68
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::TempDir;
+use predicates::prelude::*;
+use std::fs;
+
+fn specre() -> assert_cmd::Command {
+    cargo_bin_cmd!("specre")
+}
+
+fn write_config(dir: &std::path::Path, specre_dir: &str, source_dirs: &[&str]) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\n",
+        dirs_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
+fn write_config_with_ext(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    target_extensions: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let ext_toml: Vec<String> = target_extensions.iter().map(|s| format!("\"{s}\"")).collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\ntarget_extensions = [{}]\n",
+        dirs_toml.join(", "),
+        ext_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
+fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
+    let path = dir.join(rel_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+// -- Scenario: Basic coverage report --
+
+#[test]
+fn coverage_basic_report() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+    write_source(
+        tmp.path(),
+        "src/b.rs",
+        "// @specre 01BBBBBBBBBBBBBBBBBBBBBBBB\nfn b() {}\n",
+    );
+    write_source(
+        tmp.path(),
+        "src/c.rs",
+        "// @specre 01CCCCCCCCCCCCCCCCCCCCCCCC\nfn c() {}\n",
+    );
+    write_source(tmp.path(), "src/d.rs", "fn d() {}\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 3/4 files (75.0%)"));
+}
+
+// -- Scenario: Full coverage --
+
+#[test]
+fn coverage_full() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+    write_source(
+        tmp.path(),
+        "src/b.rs",
+        "// @specre 01BBBBBBBBBBBBBBBBBBBBBBBB\nfn b() {}\n",
+    );
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 2/2 files (100.0%)"));
+}
+
+// -- Scenario: No source files found --
+
+#[test]
+fn coverage_no_source_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 0/0 files (N/A)"));
+}
+
+// -- Scenario: Zero coverage --
+
+#[test]
+fn coverage_zero() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(tmp.path(), "src/a.rs", "fn a() {}\n");
+    write_source(tmp.path(), "src/b.rs", "fn b() {}\n");
+    write_source(tmp.path(), "src/c.rs", "fn c() {}\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 0/3 files (0.0%)"));
+}
+
+// -- Scenario: Extension filtering via --ext flag --
+
+#[test]
+fn coverage_ext_flag_filters() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+    write_source(tmp.path(), "src/b.ts", "// no marker\n");
+
+    // Only count .rs files
+    specre()
+        .args(["coverage", "--ext", "rs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: Extension filtering via specre.toml target_extensions --
+
+#[test]
+fn coverage_target_extensions_from_config() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_ext(tmp.path(), "docs/specres", &["src"], &["rs"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+    write_source(tmp.path(), "src/b.ts", "// no marker\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: --ext flag overrides specre.toml target_extensions --
+
+#[test]
+fn coverage_ext_flag_overrides_config() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_ext(tmp.path(), "docs/specres", &["src"], &["rs"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+    write_source(tmp.path(), "src/b.ts", "// no marker\n");
+
+    // --ext ts overrides target_extensions=["rs"] from config
+    specre()
+        .args(["coverage", "--ext", "ts"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 0/1 files (0.0%)"));
+}
+
+// -- Scenario: Uncovered files are listed --
+
+#[test]
+fn coverage_lists_uncovered_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/foo.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn foo() {}\n",
+    );
+    write_source(tmp.path(), "src/bar.rs", "fn bar() {}\n");
+    write_source(tmp.path(), "src/baz.rs", "fn baz() {}\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Coverage: 1/3 files (33.3%)")
+                .and(predicate::str::contains("Uncovered files:"))
+                .and(predicate::str::contains("src/bar.rs"))
+                .and(predicate::str::contains("src/baz.rs")),
+        );
+}
+
+// -- Scenario: Uncovered files are sorted alphabetically --
+
+#[test]
+fn coverage_uncovered_files_sorted() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(tmp.path(), "src/zebra.rs", "fn z() {}\n");
+    write_source(tmp.path(), "src/alpha.rs", "fn a() {}\n");
+
+    let output = specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let alpha_pos = stdout.find("src/alpha.rs").unwrap();
+    let zebra_pos = stdout.find("src/zebra.rs").unwrap();
+    assert!(
+        alpha_pos < zebra_pos,
+        "Uncovered files should be sorted alphabetically"
+    );
+}
+
+// -- Scenario: Paths use forward slashes --
+
+#[test]
+fn coverage_paths_use_forward_slashes() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(tmp.path(), "src/sub/deep.rs", "fn deep() {}\n");
+
+    let output = specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("src/sub/deep.rs"),
+        "Paths should use forward slashes"
+    );
+    assert!(!stdout.contains('\\'), "Paths should not contain backslashes");
+}
+
+// -- Scenario: specre.toml does not exist --
+
+#[test]
+fn coverage_errors_without_config() {
+    let tmp = TempDir::new().unwrap();
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "specre.toml not found. Run 'specre init' first.",
+        ));
+}
+
+// -- Scenario: source_dirs directory does not exist --
+
+#[test]
+fn coverage_skips_nonexistent_source_dirs() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src", "nonexistent"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Full coverage does not show uncovered section --
+
+#[test]
+fn coverage_full_no_uncovered_section() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Coverage: 1/1 files (100.0%)")
+                .and(predicate::str::contains("Uncovered files:").not()),
+        );
+}


### PR DESCRIPTION
## Summary

- Add `specre coverage` command that reports the percentage of source files linked to specre cards via `@specre` tags
- Exposes `compute_coverage() -> CoverageResult` as a public function for reuse by future commands (e.g., `health-check`)
- Supports `--ext` flag (comma-separated) to filter by file extension, overriding `target_extensions` from `specre.toml`
- Lists uncovered files alphabetically after the summary line

## Output example

```
Coverage: 3/4 files (75.0%)

Uncovered files:
  src/bar.rs
```

## Test plan

- [x] 13 integration tests covering all specre card scenarios
- [x] All 131 existing tests continue to pass
- [x] Specre card finalized as stable with `last_verified: 2026-02-15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)