### PR TITLE
Add specre card for core CLI dispatch and error handling

### DIFF
--- a/docs/specres/cli/INDEX.md
+++ b/docs/specres/cli/INDEX.md
@@ -12,3 +12,4 @@
 | [user_can_set_language_config](user_can_set_language_config.md) | stable | 2026-02-14 |
 | [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-15 |
 | [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-15 |
+| [specre_cli_dispatches_commands_and_handles_errors](specre_cli_dispatches_commands_and_handles_errors.md) | stable | 2026-02-15 |

--- a/docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md
+++ b/docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md
@@ -1,0 +1,47 @@
+---
+id: "01KHFFCX8BCDAYP8YHG0J65H0E"
+name: "specre_cli_dispatches_commands_and_handles_errors"
+status: "stable"
+last_verified: "2026-02-15"
+---
+
+## Related Files
+
+- `src/main.rs`
+- `src/cli.rs`
+- `src/commands/mod.rs`
+- `tests/cli_dispatch.rs` (Test)
+
+## Functional Overview
+
+The `specre` binary parses command-line arguments via clap, dispatches each subcommand to its corresponding handler, and provides uniform error handling. When any handler returns an error, the binary prints the message to stderr with an `Error:` prefix and exits with code 1.
+
+## Design Intent
+
+The dispatch layer exists to provide a consistent interface and error behavior across all specre subcommands. By centralizing argument parsing (`cli.rs`), module registration (`commands/mod.rs`), and error handling (`main.rs`) in three thin files, each individual command handler can focus purely on its domain logic and return `Result` without worrying about exit codes or output formatting.
+
+## Key Members
+
+- `Cli` — top-level clap struct with a single `command: Commands` field
+- `Commands` — enum of all subcommands (`Init`, `New`, `Index`, `Status`, `Trace`, `Orphans`, `Tag`, `Coverage`), each variant holding its respective `Args` struct or no data
+- `main()` — parses `Cli`, matches on `Commands`, calls the handler's `execute()`, and converts `Err` to stderr + exit code 1
+
+## Scenarios
+
+### Dispatches a valid subcommand to its handler
+
+1. User runs `specre init` (or any other valid subcommand)
+2. CLI parses the arguments and identifies the subcommand
+3. CLI calls the corresponding handler's `execute()` function
+4. The handler runs successfully and the process exits with code 0
+
+### Exits with error when handler fails
+
+1. User runs a subcommand that triggers an error in its handler (e.g., `specre status` without `specre.toml`)
+2. The handler returns `Err` with an error message
+3. CLI prints `Error: <message>` to stderr
+4. CLI exits with code 1
+
+## Failures / Exceptions
+
+- If a handler returns `Err`, the error message is printed to stderr with `Error:` prefix and the process exits with code 1

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-15T01:31:24Z",
+  "generated_at": "2026-02-15T01:48:35Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -81,9 +81,22 @@
       "domain": "cli",
       "path": "docs/specres/cli/specre_coverage_reports_source_file_tagging.md",
       "last_verified": "2026-02-15"
+    },
+    {
+      "id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "name": "specre_cli_dispatches_commands_and_handles_errors",
+      "status": "stable",
+      "domain": "cli",
+      "path": "docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md",
+      "last_verified": "2026-02-15"
     }
   ],
   "source_refs": [
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/cli.rs",
+      "line": 1
+    },
     {
       "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
       "file": "src/commands/coverage.rs",
@@ -123,6 +136,11 @@
       "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9",
       "file": "src/commands/init.rs",
       "line": 2
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/commands/mod.rs",
+      "line": 1
     },
     {
       "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -195,6 +213,11 @@
       "line": 8
     },
     {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/main.rs",
+      "line": 1
+    },
+    {
       "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
       "file": "src/template.rs",
       "line": 1
@@ -212,6 +235,11 @@
     {
       "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
       "file": "tests/cli_coverage.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "tests/cli_dispatch.rs",
       "line": 1
     },
     {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+// @specre 01KHFFCX8BCDAYP8YHG0J65H0E
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+// @specre 01KHFFCX8BCDAYP8YHG0J65H0E
 pub mod coverage;
 pub mod index;
 pub mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+// @specre 01KHFFCX8BCDAYP8YHG0J65H0E
 mod cli;
 mod commands;
 mod config;

--- a/tests/cli_dispatch.rs
+++ b/tests/cli_dispatch.rs
@@ -1,0 +1,37 @@
+// @specre 01KHFFCX8BCDAYP8YHG0J65H0E
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::TempDir;
+use predicates::prelude::*;
+
+fn specre() -> assert_cmd::Command {
+    cargo_bin_cmd!("specre")
+}
+
+// -- Scenario: Dispatches a valid subcommand to its handler --
+
+#[test]
+fn dispatch_valid_subcommand_exits_successfully() {
+    let tmp = TempDir::new().unwrap();
+
+    specre()
+        .args(["init"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+// -- Scenario: Exits with error when handler fails --
+
+#[test]
+fn dispatch_handler_error_prints_to_stderr_and_exits_with_code_1() {
+    let tmp = TempDir::new().unwrap();
+
+    // Running `specre status` without specre.toml triggers a handler error
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::starts_with("Error: "));
+}


### PR DESCRIPTION
## Summary

- Add specre card `specre_cli_dispatches_commands_and_handles_errors` covering the 3 remaining uncovered core files (`src/main.rs`, `src/cli.rs`, `src/commands/mod.rs`)
- Add integration tests in `tests/cli_dispatch.rs` (2 tests: successful dispatch + error handling with exit code 1)
- Add `@specre` tags to all 3 source files
- Coverage: 86.4% (19/22) → **100%** (23/23)

## Test plan

- [x] `cargo test` — all 135 tests pass
- [x] `specre coverage` — 100%
- [x] `specre index` — regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)