### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "specre"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specre"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "Atomic, living specification cards for AI-agent-friendly development"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.2.3 to 0.2.4 in Cargo.toml and Cargo.lock

## Release
This PR is part of the v0.2.4 release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)