### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "specre"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specre"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "Atomic, living specification cards for AI-agent-friendly development"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.2.4 to 0.2.5 in preparation for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)