### PR TITLE
feat: add --json flag for machine-readable output

### DIFF
--- a/docs/specres/cli/INDEX.md
+++ b/docs/specres/cli/INDEX.md
@@ -15,3 +15,4 @@
 | [specre_cli_dispatches_commands_and_handles_errors](specre_cli_dispatches_commands_and_handles_errors.md) | stable | 2026-02-15 |
 | [specre_health_check_verifies_ecosystem_trustworthiness](specre_health_check_verifies_ecosystem_trustworthiness.md) | stable | 2026-02-15 |
 | [specre_search_finds_specre_cards_by_query](specre_search_finds_specre_cards_by_query.md) | stable | 2026-02-15 |
+| [specre_commands_support_json_output](specre_commands_support_json_output.md) | stable | 2026-02-15 |

--- a/docs/specres/cli/specre_commands_support_json_output.md
+++ b/docs/specres/cli/specre_commands_support_json_output.md
@@ -1,0 +1,245 @@
+---
+id: "01KHG0A2V4YXE918WMJCY7WFE8"
+name: "specre_commands_support_json_output"
+status: "stable"
+last_verified: "2026-02-15"
+---
+
+## Related Files
+
+- `src/cli.rs`
+- `src/main.rs`
+- `src/commands/mod.rs`
+- `src/commands/status.rs`
+- `src/commands/trace.rs`
+- `src/commands/orphans.rs`
+- `src/commands/coverage.rs`
+- `src/commands/init.rs`
+- `src/commands/new.rs`
+- `src/commands/tag.rs`
+- `src/commands/index.rs`
+- `tests/cli_json_output.rs` (Test)
+
+## Functional Overview
+
+All specre CLI commands support a `--json` flag that switches output from human-readable text to structured JSON on stdout. This enables AI agents and scripts to consume specre output programmatically without parsing free-form text. Commands that already output JSON (`search`, `health-check`) accept the flag but their output is unchanged. The flag is defined as a global option on the top-level CLI struct and propagated to each subcommand handler.
+
+## Design Intent
+
+The v0.3 roadmap targets agent integration. Agents need machine-readable output to make decisions. While `search` and `health-check` were designed JSON-first, the remaining commands (`status`, `trace`, `orphans`, `coverage`, `init`, `new`, `tag`, `index`) output human-readable text that is fragile to parse. Adding `--json` across all commands provides a uniform, predictable interface for any consumer — whether an MCP server, a CI script, or a coding agent.
+
+## Key Members
+
+- `Cli.json: bool` — global flag (`--json`) on the top-level clap struct, defaults to `false`
+- Each command handler receives the `json` flag and branches output accordingly
+- All JSON output uses `serde_json::to_string_pretty` for consistency with existing commands
+
+## Scenarios
+
+### status --json outputs structured JSON
+
+1. Project has specre cards in various statuses, some stale
+2. User runs `specre status --json`
+3. CLI outputs JSON to stdout:
+   ```json
+   {
+     "summary": {
+       "draft": 2,
+       "in_development": 1,
+       "stable": 3,
+       "deprecated": 0,
+       "total": 6
+     },
+     "stale": [
+       {
+         "name": "user_can_reset_password",
+         "path": "docs/specres/auth/user_can_reset_password.md",
+         "reason": "45 days"
+       }
+     ]
+   }
+   ```
+4. CLI exits with exit code 0
+
+### status without --json is unchanged
+
+1. User runs `specre status` (no `--json` flag)
+2. CLI outputs the same human-readable text format as before
+3. Backward compatibility is preserved
+
+### trace --json outputs structured JSON (ULID lookup)
+
+1. User runs `specre trace --json 01HZYPMZRK8F9R2DGBGGMM2N8T`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "specre": "docs/specres/cli/user_can_sign_up_with_email.md",
+     "source_refs": [
+       { "file": "src/auth/signup.rs", "line": 1 }
+     ]
+   }
+   ```
+3. CLI exits with exit code 0
+
+### trace --json outputs structured JSON (file lookup)
+
+1. User runs `specre trace --json src/auth/signup.rs`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "file": "src/auth/signup.rs",
+     "specres": [
+       { "id": "01HZYPMZRK8F9R2DGBGGMM2N8T", "path": "docs/specres/cli/user_can_sign_up_with_email.md" }
+     ]
+   }
+   ```
+3. CLI exits with exit code 0
+
+### trace --json with unknown ULID
+
+1. User runs `specre trace --json 01ZZZZZZZZZZZZZZZZZZZZZZZZ`
+2. CLI outputs JSON with `"specre": null` and empty `source_refs`
+3. CLI exits with exit code 1 (same error semantics as text mode)
+
+### orphans --json outputs structured JSON
+
+1. User runs `specre orphans --json`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "orphan_specres": [
+       "docs/specres/auth/user_can_reset_password.md"
+     ],
+     "dangling_markers": [
+       { "file": "src/old_module.rs", "line": 5, "id": "01ZZZZZZZZZZZZZZZZZZZZZZZZ" }
+     ]
+   }
+   ```
+3. CLI exits with exit code 1 (same error semantics: non-zero when orphans exist)
+
+### orphans --json with no orphans
+
+1. User runs `specre orphans --json` in a clean project
+2. CLI outputs JSON:
+   ```json
+   {
+     "orphan_specres": [],
+     "dangling_markers": []
+   }
+   ```
+3. CLI exits with exit code 0
+
+### coverage --json outputs structured JSON
+
+1. User runs `specre coverage --json`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "total": 10,
+     "tagged": 8,
+     "coverage": 0.8,
+     "uncovered": [
+       "src/utils/helper.rs",
+       "src/utils/format.rs"
+     ]
+   }
+   ```
+3. CLI exits with exit code 0
+
+### coverage --json with --ext filter
+
+1. User runs `specre coverage --json --ext rs`
+2. CLI applies the extension filter and outputs the same JSON structure, filtered to `.rs` files only
+
+### init --json outputs structured JSON
+
+1. User runs `specre init --json`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "specre_dir": "docs/specres",
+     "config_file": "specre.toml"
+   }
+   ```
+3. CLI exits with exit code 0
+
+### new --json outputs structured JSON
+
+1. User runs `specre new docs/specres/cli --name user_can_do_thing --json`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "id": "01HZYPMZRK8F9R2DGBGGMM2N8T",
+     "path": "docs/specres/cli/user_can_do_thing.md"
+   }
+   ```
+3. CLI exits with exit code 0
+
+### tag --json outputs structured JSON
+
+1. User runs `specre tag --json 01HZYPMZRK8F9R2DGBGGMM2N8T src/main.rs`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "id": "01HZYPMZRK8F9R2DGBGGMM2N8T",
+     "file": "src/main.rs",
+     "line": 1
+   }
+   ```
+3. CLI exits with exit code 0
+
+### index --json outputs structured JSON
+
+1. User runs `specre index --json`
+2. CLI outputs JSON to stdout:
+   ```json
+   {
+     "index_file": "index.json",
+     "specre_count": 12,
+     "source_ref_count": 8,
+     "index_md_files": [
+       "docs/specres/cli/INDEX.md",
+       "docs/specres/auth/INDEX.md"
+     ]
+   }
+   ```
+3. CLI exits with exit code 0
+
+### search --json is accepted but output is unchanged
+
+1. `search` already outputs JSON by default
+2. User runs `specre search --json "password"`
+3. Output is identical to `specre search "password"`
+4. The flag is accepted without error
+
+### health-check --json is accepted but output is unchanged
+
+1. `health-check` already outputs JSON by default
+2. User runs `specre health-check --json`
+3. Output is identical to `specre health-check`
+4. The flag is accepted without error
+
+### --json flag placement is flexible
+
+1. The `--json` flag is a global option on the top-level `Cli` struct
+2. It can appear before or after the subcommand: `specre --json status` and `specre status --json` both work
+3. This is the standard clap behavior for global options propagated to subcommands
+
+### Error output goes to stderr regardless of --json
+
+1. User runs `specre status --json` without `specre.toml`
+2. CLI outputs `Error: specre.toml not found. Run 'specre init' first.` to stderr (not JSON)
+3. CLI exits with exit code 1
+4. Error messages are never wrapped in JSON — stderr is always plain text
+
+### specre.toml does not exist
+
+1. User runs any command with `--json` in a directory without `specre.toml`
+2. CLI outputs the same error to stderr as without `--json`
+3. CLI exits with exit code 1
+
+## Failures / Exceptions
+
+- Error messages always go to stderr as plain text, regardless of `--json`. JSON is only for successful structured output on stdout.
+- If serialization fails (should not happen in practice), CLI outputs `Error: Failed to serialize: <details>` to stderr and exits with exit code 1.
+- Commands that already output JSON (`search`, `health-check`) are unaffected by the flag — their output format does not change.

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-15T05:27:25Z",
+  "generated_at": "2026-02-15T06:49:27Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -105,6 +105,14 @@
       "domain": "cli",
       "path": "docs/specres/cli/specre_search_finds_specre_cards_by_query.md",
       "last_verified": "2026-02-15"
+    },
+    {
+      "id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "name": "specre_commands_support_json_output",
+      "status": "stable",
+      "domain": "cli",
+      "path": "docs/specres/cli/specre_commands_support_json_output.md",
+      "last_verified": "2026-02-15"
     }
   ],
   "source_refs": [
@@ -117,6 +125,11 @@
       "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
       "file": "src/commands/coverage.rs",
       "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/coverage.rs",
+      "line": 2
     },
     {
       "specre_id": "01KHFGVXWP100JXYBZTRJGMB9H",
@@ -149,6 +162,11 @@
       "line": 5
     },
     {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/index.rs",
+      "line": 6
+    },
+    {
       "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
       "file": "src/commands/init.rs",
       "line": 1
@@ -157,6 +175,11 @@
       "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9",
       "file": "src/commands/init.rs",
       "line": 2
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/init.rs",
+      "line": 3
     },
     {
       "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
@@ -174,9 +197,19 @@
       "line": 2
     },
     {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/new.rs",
+      "line": 3
+    },
+    {
       "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
       "file": "src/commands/orphans.rs",
       "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/orphans.rs",
+      "line": 2
     },
     {
       "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49",
@@ -189,14 +222,29 @@
       "line": 1
     },
     {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/status.rs",
+      "line": 2
+    },
+    {
       "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
       "file": "src/commands/tag.rs",
       "line": 1
     },
     {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/tag.rs",
+      "line": 2
+    },
+    {
       "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
       "file": "src/commands/trace.rs",
       "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/trace.rs",
+      "line": 2
     },
     {
       "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
@@ -281,6 +329,11 @@
     {
       "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
       "file": "tests/cli_init.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "tests/cli_json_output.rs",
       "line": 1
     },
     {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,10 @@ use clap::{Args, Parser, Subcommand};
     about = "Atomic specification cards for AI-agent-friendly development"
 )]
 pub struct Cli {
+    /// Output in JSON format (machine-readable)
+    #[arg(long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -1,9 +1,19 @@
 // @specre 01KHFEA9QVV4A127VCRJY97A68
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::CoverageArgs;
 use crate::commands::index::{collect_all_files, extract_marker_ulid, to_forward_slash};
 use crate::config;
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
+
+#[derive(Serialize)]
+struct CoverageOutput {
+    total: usize,
+    tagged: usize,
+    coverage: f64,
+    uncovered: Vec<String>,
+}
 
 pub struct CoverageResult {
     pub total: usize,
@@ -53,7 +63,7 @@ pub fn compute_coverage(
     }
 }
 
-pub fn execute(args: CoverageArgs) -> Result<(), String> {
+pub fn execute(args: CoverageArgs, json: bool) -> Result<(), String> {
     let config = config::load()?;
 
     let extensions = args
@@ -62,18 +72,35 @@ pub fn execute(args: CoverageArgs) -> Result<(), String> {
 
     let result = compute_coverage(&config.source_dirs, extensions.as_deref());
 
-    if result.total == 0 {
-        println!("Coverage: 0/0 files (N/A)");
+    if json {
+        let coverage_ratio = if result.total == 0 {
+            0.0
+        } else {
+            result.tagged as f64 / result.total as f64
+        };
+        let output = CoverageOutput {
+            total: result.total,
+            tagged: result.tagged,
+            coverage: coverage_ratio,
+            uncovered: result.uncovered,
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
     } else {
-        let pct = result.tagged as f64 / result.total as f64 * 100.0;
-        println!("Coverage: {}/{} files ({:.1}%)", result.tagged, result.total, pct);
-    }
+        if result.total == 0 {
+            println!("Coverage: 0/0 files (N/A)");
+        } else {
+            let pct = result.tagged as f64 / result.total as f64 * 100.0;
+            println!("Coverage: {}/{} files ({:.1}%)", result.tagged, result.total, pct);
+        }
 
-    if !result.uncovered.is_empty() {
-        println!();
-        println!("Uncovered files:");
-        for path in &result.uncovered {
-            println!("  {path}");
+        if !result.uncovered.is_empty() {
+            println!();
+            println!("Uncovered files:");
+            for path in &result.uncovered {
+                println!("  {path}");
+            }
         }
     }
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -3,12 +3,21 @@
 // @specre 01KHB48DYZDN8GHXPX7MSYJ1NZ
 // @specre 01KHAKAYN5WPTDVR99D5Q5TMJE
 // @specre 01KHFD5R1G3C5R34XMQXQTTMM9
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::config;
 use chrono::Utc;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Serialize)]
+struct IndexOutput {
+    index_file: String,
+    specre_count: usize,
+    source_ref_count: usize,
+    index_md_files: Vec<String>,
+}
 
 #[derive(Serialize)]
 struct Index {
@@ -35,7 +44,7 @@ struct SourceRef {
     line: usize,
 }
 
-pub fn execute() -> Result<(), String> {
+pub fn execute(json_flag: bool) -> Result<(), String> {
     let config = config::load()?;
 
     let specre_dir = Path::new(&config.specre_dir);
@@ -53,13 +62,28 @@ pub fn execute() -> Result<(), String> {
         serde_json::to_string_pretty(&index).map_err(|e| format!("Failed to serialize: {e}"))?;
     fs::write("index.json", &json).map_err(|e| format!("Failed to write index.json: {e}"))?;
 
-    println!(
-        "Generated index.json ({} specres, {} source refs)",
-        index.specres.len(),
-        index.source_refs.len()
-    );
+    let index_md_files = generate_index_md(specre_dir, &config.specre_dir, &index.specres)?;
 
-    generate_index_md(specre_dir, &config.specre_dir, &index.specres)?;
+    if json_flag {
+        let output = IndexOutput {
+            index_file: "index.json".to_string(),
+            specre_count: index.specres.len(),
+            source_ref_count: index.source_refs.len(),
+            index_md_files,
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+    } else {
+        println!(
+            "Generated index.json ({} specres, {} source refs)",
+            index.specres.len(),
+            index.source_refs.len()
+        );
+        for md_file in &index_md_files {
+            println!("Generated {md_file}");
+        }
+    }
 
     Ok(())
 }
@@ -286,7 +310,7 @@ fn generate_index_md(
     specre_dir: &Path,
     specre_dir_str: &str,
     specres: &[SpecreEntry],
-) -> Result<(), String> {
+) -> Result<Vec<String>, String> {
     // Group specres by domain
     let mut by_domain: BTreeMap<String, Vec<&SpecreEntry>> = BTreeMap::new();
     for entry in specres {
@@ -301,6 +325,8 @@ fn generate_index_md(
     } else {
         format!("{specre_dir_str}/")
     };
+
+    let mut generated_files = Vec::new();
 
     for (domain, entries) in &by_domain {
         let domain_dir = specre_dir.join(domain);
@@ -329,8 +355,8 @@ fn generate_index_md(
 
         let index_rel =
             to_forward_slash(&PathBuf::from(specre_dir_str).join(domain).join("INDEX.md"));
-        println!("Generated {index_rel}");
+        generated_files.push(index_rel);
     }
 
-    Ok(())
+    Ok(generated_files)
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,12 +1,20 @@
 // @specre 01KHAGG8NQQ7RSNYZ6SWBCYH3N
 // @specre 01KHFD5R1G3C5R34XMQXQTTMM9
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::InitArgs;
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
 
+#[derive(Serialize)]
+struct InitOutput {
+    specre_dir: String,
+    config_file: String,
+}
+
 const CONFIG_FILE: &str = "specre.toml";
 
-pub fn execute(args: InitArgs) -> Result<(), String> {
+pub fn execute(args: InitArgs, json: bool) -> Result<(), String> {
     let config_path = Path::new(CONFIG_FILE);
 
     if config_path.exists() {
@@ -21,8 +29,10 @@ pub fn execute(args: InitArgs) -> Result<(), String> {
     if !dir_already_existed {
         fs::create_dir_all(specre_dir)
             .map_err(|e| format!("Failed to create directory '{}': {e}", specre_dir.display()))?;
-        println!("Created {}/", args.specre_dir);
-    } else {
+        if !json {
+            println!("Created {}/", args.specre_dir);
+        }
+    } else if !json {
         println!("Exists  {}/", args.specre_dir);
     }
 
@@ -51,7 +61,17 @@ pub fn execute(args: InitArgs) -> Result<(), String> {
     fs::write(config_path, &config_content)
         .map_err(|e| format!("Failed to write {CONFIG_FILE}: {e}"))?;
 
-    println!("Created {CONFIG_FILE}");
+    if json {
+        let output = InitOutput {
+            specre_dir: args.specre_dir,
+            config_file: CONFIG_FILE.to_string(),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+    } else {
+        println!("Created {CONFIG_FILE}");
+    }
 
     Ok(())
 }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,13 +1,22 @@
 // @specre 01JMBJK7QRVX3N4P5G6H8W9Y0Z
 // @specre 01KHDF9WHR5HFM4RQCF6HS3KCC
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::NewArgs;
+use crate::commands::index::to_forward_slash;
 use crate::config;
 use crate::template;
 use crate::ulid;
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
 
-pub fn execute(args: NewArgs) -> Result<(), String> {
+#[derive(Serialize)]
+struct NewOutput {
+    id: String,
+    path: String,
+}
+
+pub fn execute(args: NewArgs, json: bool) -> Result<(), String> {
     let target = Path::new(&args.target_dir);
 
     if target.is_file() {
@@ -33,7 +42,17 @@ pub fn execute(args: NewArgs) -> Result<(), String> {
     fs::write(&file_path, &content)
         .map_err(|e| format!("Failed to write '{}': {e}", file_path.display()))?;
 
-    println!("{}", file_path.display());
+    if json {
+        let output = NewOutput {
+            id,
+            path: to_forward_slash(&file_path),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+    } else {
+        println!("{}", file_path.display());
+    }
 
     Ok(())
 }

--- a/src/commands/orphans.rs
+++ b/src/commands/orphans.rs
@@ -1,8 +1,10 @@
 // @specre 01KHB48EES4FR5TFV6ZP2W3MGT
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::commands::index::{
     collect_all_files, collect_md_files, extract_marker_ulid, parse_frontmatter, to_forward_slash,
 };
 use crate::config;
+use serde::Serialize;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -17,6 +19,19 @@ struct DanglingMarker {
     file: String,
     line: usize,
     ulid: String,
+}
+
+#[derive(Serialize)]
+struct OrphansOutput {
+    orphan_specres: Vec<String>,
+    dangling_markers: Vec<DanglingMarkerOutput>,
+}
+
+#[derive(Serialize)]
+struct DanglingMarkerOutput {
+    file: String,
+    line: usize,
+    id: String,
 }
 
 pub struct OrphanResult {
@@ -87,7 +102,7 @@ pub fn compute_orphans(
     }
 }
 
-pub fn execute() -> Result<(), String> {
+pub fn execute(json: bool) -> Result<(), String> {
     let config = config::load()?;
     let specre_dir = Path::new(&config.specre_dir);
 
@@ -160,6 +175,28 @@ pub fn execute() -> Result<(), String> {
     orphans.sort_by(|a, b| a.path.cmp(&b.path));
 
     dangling.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+
+    if json {
+        let output = OrphansOutput {
+            orphan_specres: orphans.iter().map(|s| s.path.clone()).collect(),
+            dangling_markers: dangling
+                .iter()
+                .map(|d| DanglingMarkerOutput {
+                    file: d.file.clone(),
+                    line: d.line,
+                    id: d.ulid.clone(),
+                })
+                .collect(),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+
+        if orphans.is_empty() && dangling.is_empty() {
+            return Ok(());
+        }
+        return Err(String::new());
+    }
 
     if orphans.is_empty() && dangling.is_empty() {
         println!("No orphans or dangling markers found.");

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,10 +1,34 @@
 // @specre 01KHAN6JE712ZAKXPP97854PKJ
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::StatusArgs;
 use crate::commands::index::{collect_md_files, parse_frontmatter, to_forward_slash};
 use crate::config;
 use chrono::{NaiveDate, Utc};
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
+
+#[derive(Serialize)]
+struct StatusOutput {
+    summary: StatusSummary,
+    stale: Vec<StaleOutput>,
+}
+
+#[derive(Serialize)]
+struct StatusSummary {
+    draft: u32,
+    in_development: u32,
+    stable: u32,
+    deprecated: u32,
+    total: u32,
+}
+
+#[derive(Serialize)]
+struct StaleOutput {
+    name: String,
+    path: String,
+    reason: String,
+}
 
 struct StaleEntry {
     name: String,
@@ -12,7 +36,7 @@ struct StaleEntry {
     reason: String,
 }
 
-pub fn execute(args: StatusArgs) -> Result<(), String> {
+pub fn execute(args: StatusArgs, json: bool) -> Result<(), String> {
     let config = config::load()?;
     let specre_dir = Path::new(&config.specre_dir);
 
@@ -84,18 +108,41 @@ pub fn execute(args: StatusArgs) -> Result<(), String> {
 
     let total = draft + in_development + stable + deprecated;
 
-    println!("Status Summary:");
-    println!("  draft:          {draft}");
-    println!("  in-development: {in_development}");
-    println!("  stable:         {stable}");
-    println!("  deprecated:     {deprecated}");
-    println!("  total:          {total}");
+    if json {
+        let output = StatusOutput {
+            summary: StatusSummary {
+                draft,
+                in_development,
+                stable,
+                deprecated,
+                total,
+            },
+            stale: stale_entries
+                .iter()
+                .map(|e| StaleOutput {
+                    name: e.name.clone(),
+                    path: e.path.clone(),
+                    reason: e.reason.clone(),
+                })
+                .collect(),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+    } else {
+        println!("Status Summary:");
+        println!("  draft:          {draft}");
+        println!("  in-development: {in_development}");
+        println!("  stable:         {stable}");
+        println!("  deprecated:     {deprecated}");
+        println!("  total:          {total}");
 
-    if !stale_entries.is_empty() {
-        println!();
-        println!("Stale specres (last_verified > {threshold} days):");
-        for entry in &stale_entries {
-            println!("  {}  {}  ({})", entry.name, entry.path, entry.reason);
+        if !stale_entries.is_empty() {
+            println!();
+            println!("Stale specres (last_verified > {threshold} days):");
+            for entry in &stale_entries {
+                println!("  {}  {}  ({})", entry.name, entry.path, entry.reason);
+            }
         }
     }
 

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -1,8 +1,17 @@
 // @specre 01KHB48EYB9686YYQMYFYQ5R1Z
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::TagArgs;
 use crate::ulid;
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
+
+#[derive(Serialize)]
+struct TagOutput {
+    id: String,
+    file: String,
+    line: usize,
+}
 
 fn comment_syntax(ext: &str) -> Option<(&'static str, &'static str)> {
     match ext {
@@ -47,7 +56,7 @@ fn to_forward_slash(s: &str) -> String {
     s.replace('\\', "/")
 }
 
-pub fn execute(args: TagArgs) -> Result<(), String> {
+pub fn execute(args: TagArgs, json: bool) -> Result<(), String> {
     if !ulid::is_valid(&args.ulid) {
         return Err(
             "invalid ULID format. Expected 26 uppercase alphanumeric characters.".to_string(),
@@ -73,7 +82,24 @@ pub fn execute(args: TagArgs) -> Result<(), String> {
     // Check if marker already exists
     let marker_pattern = format!("@specre {}", args.ulid);
     if content.contains(&marker_pattern) {
-        println!("Marker already exists in {}", to_forward_slash(&args.file));
+        if json {
+            // Find the line number of the existing marker
+            let line = content
+                .lines()
+                .position(|l| l.contains(&marker_pattern))
+                .map(|n| n + 1)
+                .unwrap_or(1);
+            let output = TagOutput {
+                id: args.ulid,
+                file: to_forward_slash(&args.file),
+                line,
+            };
+            let json_str = serde_json::to_string_pretty(&output)
+                .map_err(|e| format!("Failed to serialize: {e}"))?;
+            println!("{json_str}");
+        } else {
+            println!("Marker already exists in {}", to_forward_slash(&args.file));
+        }
         return Ok(());
     }
 
@@ -92,7 +118,18 @@ pub fn execute(args: TagArgs) -> Result<(), String> {
     fs::write(file_path, &new_content)
         .map_err(|e| format!("Failed to write '{}': {e}", args.file))?;
 
-    println!("Tagged {} with {}", to_forward_slash(&args.file), args.ulid);
+    if json {
+        let output = TagOutput {
+            id: args.ulid,
+            file: to_forward_slash(&args.file),
+            line: 1,
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
+    } else {
+        println!("Tagged {} with {}", to_forward_slash(&args.file), args.ulid);
+    }
 
     Ok(())
 }

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1,23 +1,49 @@
 // @specre 01KHB48DYZDN8GHXPX7MSYJ1NZ
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
 use crate::cli::TraceArgs;
 use crate::commands::index::{
     collect_all_files, collect_md_files, extract_marker_ulid, parse_frontmatter, to_forward_slash,
 };
 use crate::config;
 use crate::ulid;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-pub fn execute(args: TraceArgs) -> Result<(), String> {
+#[derive(Serialize)]
+struct TraceByUlidOutput {
+    specre: Option<String>,
+    source_refs: Vec<SourceRefOutput>,
+}
+
+#[derive(Serialize)]
+struct SourceRefOutput {
+    file: String,
+    line: usize,
+}
+
+#[derive(Serialize)]
+struct TraceByFileOutput {
+    file: String,
+    specres: Vec<SpecreRefOutput>,
+}
+
+#[derive(Serialize)]
+struct SpecreRefOutput {
+    id: String,
+    path: Option<String>,
+}
+
+pub fn execute(args: TraceArgs, json: bool) -> Result<(), String> {
     if ulid::is_valid(&args.query) {
-        trace_by_ulid(&args.query)
+        trace_by_ulid(&args.query, json)
     } else {
-        trace_by_file(&args.query)
+        trace_by_file(&args.query, json)
     }
 }
 
-fn trace_by_ulid(ulid: &str) -> Result<(), String> {
+fn trace_by_ulid(ulid: &str, json: bool) -> Result<(), String> {
     let config = config::load()?;
     let specre_dir = Path::new(&config.specre_dir);
 
@@ -64,20 +90,36 @@ fn trace_by_ulid(ulid: &str) -> Result<(), String> {
     }
     source_refs.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 
-    // Print output
-    println!("Specre:");
-    match &specre_path {
-        Some(p) => println!("  {p}"),
-        None => println!("  (not found)"),
-    }
-
-    println!();
-    println!("Source references:");
-    if source_refs.is_empty() {
-        println!("  (none)");
+    if json {
+        let output = TraceByUlidOutput {
+            specre: specre_path.clone(),
+            source_refs: source_refs
+                .iter()
+                .map(|(file, line)| SourceRefOutput {
+                    file: file.clone(),
+                    line: *line,
+                })
+                .collect(),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
     } else {
-        for (file, line) in &source_refs {
-            println!("  {file}:{line}");
+        // Print output
+        println!("Specre:");
+        match &specre_path {
+            Some(p) => println!("  {p}"),
+            None => println!("  (not found)"),
+        }
+
+        println!();
+        println!("Source references:");
+        if source_refs.is_empty() {
+            println!("  (none)");
+        } else {
+            for (file, line) in &source_refs {
+                println!("  {file}:{line}");
+            }
         }
     }
 
@@ -89,7 +131,7 @@ fn trace_by_ulid(ulid: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn trace_by_file(file_path: &str) -> Result<(), String> {
+fn trace_by_file(file_path: &str, json: bool) -> Result<(), String> {
     let file_path = file_path.replace('\\', "/");
     let path = Path::new(&file_path);
     if !path.exists() {
@@ -126,17 +168,33 @@ fn trace_by_file(file_path: &str) -> Result<(), String> {
         });
     }
 
-    // Print output
-    println!("File: {file_path}");
-    println!();
-    println!("Specres:");
-    if ulids.is_empty() {
-        println!("  (none)");
+    if json {
+        let output = TraceByFileOutput {
+            file: file_path.clone(),
+            specres: ulids
+                .iter()
+                .map(|u| SpecreRefOutput {
+                    id: u.clone(),
+                    path: ulid_to_path.get(u).cloned(),
+                })
+                .collect(),
+        };
+        let json_str = serde_json::to_string_pretty(&output)
+            .map_err(|e| format!("Failed to serialize: {e}"))?;
+        println!("{json_str}");
     } else {
-        for ulid in &ulids {
-            match ulid_to_path.get(ulid) {
-                Some(specre_path) => println!("  {ulid}  {specre_path}"),
-                None => println!("  {ulid}  (not found)"),
+        // Print output
+        println!("File: {file_path}");
+        println!();
+        println!("Specres:");
+        if ulids.is_empty() {
+            println!("  (none)");
+        } else {
+            for ulid in &ulids {
+                match ulid_to_path.get(ulid) {
+                    Some(specre_path) => println!("  {ulid}  {specre_path}"),
+                    None => println!("  {ulid}  (not found)"),
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,16 +11,17 @@ use std::process;
 
 fn main() {
     let cli = Cli::parse();
+    let json = cli.json;
 
     let result = match cli.command {
-        Commands::Init(args) => commands::init::execute(args),
-        Commands::New(args) => commands::new::execute(args),
-        Commands::Index => commands::index::execute(),
-        Commands::Status(args) => commands::status::execute(args),
-        Commands::Trace(args) => commands::trace::execute(args),
-        Commands::Orphans => commands::orphans::execute(),
-        Commands::Tag(args) => commands::tag::execute(args),
-        Commands::Coverage(args) => commands::coverage::execute(args),
+        Commands::Init(args) => commands::init::execute(args, json),
+        Commands::New(args) => commands::new::execute(args, json),
+        Commands::Index => commands::index::execute(json),
+        Commands::Status(args) => commands::status::execute(args, json),
+        Commands::Trace(args) => commands::trace::execute(args, json),
+        Commands::Orphans => commands::orphans::execute(json),
+        Commands::Tag(args) => commands::tag::execute(args, json),
+        Commands::Coverage(args) => commands::coverage::execute(args, json),
         Commands::HealthCheck => commands::health_check::execute(),
         Commands::Search(args) => commands::search::execute(args),
     };

--- a/tests/cli_json_output.rs
+++ b/tests/cli_json_output.rs
@@ -1,0 +1,529 @@
+// @specre 01KHG0A2V4YXE918WMJCY7WFE8
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::TempDir;
+use predicates::prelude::*;
+use serde_json::Value;
+use std::fs;
+
+fn specre() -> assert_cmd::Command {
+    cargo_bin_cmd!("specre")
+}
+
+/// Helper: create specre.toml with given specre_dir and source_dirs
+fn write_config(dir: &std::path::Path, specre_dir: &str) {
+    let content = format!("specre_dir = \"{specre_dir}\"\nsource_dirs = [\"src\"]\n");
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
+/// Helper: create a specre .md file with front-matter
+fn write_specre(
+    dir: &std::path::Path,
+    rel_path: &str,
+    id: &str,
+    name: &str,
+    status: &str,
+    last_verified: Option<&str>,
+) {
+    let path = dir.join(rel_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut fm = format!("---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n");
+    if let Some(lv) = last_verified {
+        fm.push_str(&format!("last_verified: \"{lv}\"\n"));
+    }
+    fm.push_str("---\n\n## Related Files\n\n-\n");
+    fs::write(path, fm).unwrap();
+}
+
+/// Helper: create a source file with @specre marker
+fn write_source(dir: &std::path::Path, rel_path: &str, ulid: &str) {
+    let path = dir.join(rel_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let content = format!("// @specre {ulid}\nfn main() {{}}\n");
+    fs::write(path, content).unwrap();
+}
+
+/// Helper: create a source file without @specre marker
+fn write_source_no_marker(dir: &std::path::Path, rel_path: &str) {
+    let path = dir.join(rel_path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, "fn main() {}\n").unwrap();
+}
+
+/// Helper: parse stdout as JSON Value
+fn parse_json(output: &assert_cmd::assert::Assert) -> Value {
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    serde_json::from_str(&stdout).expect("stdout should be valid JSON")
+}
+
+// ============================================================
+// status --json
+// ============================================================
+
+#[test]
+fn status_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "draft",
+        None,
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_b.md",
+        "01BBBBBBBBBBBBBBBBBBBBBBBB",
+        "spec_b",
+        "in-development",
+        None,
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_c.md",
+        "01CCCCCCCCCCCCCCCCCCCCCCCC",
+        "spec_c",
+        "stable",
+        Some("2026-02-15"),
+    );
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_d.md",
+        "01DDDDDDDDDDDDDDDDDDDDDD",
+        "spec_d",
+        "deprecated",
+        None,
+    );
+
+    let assert = specre()
+        .args(["status", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    let summary = &json["summary"];
+    assert_eq!(summary["draft"], 1);
+    assert_eq!(summary["in_development"], 1);
+    assert_eq!(summary["stable"], 1);
+    assert_eq!(summary["deprecated"], 1);
+    assert_eq!(summary["total"], 4);
+    assert!(json["stale"].is_array());
+}
+
+#[test]
+fn status_json_includes_stale_specres() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/auth/stale_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "stale_spec",
+        "stable",
+        Some("2025-01-01"),
+    );
+
+    let assert = specre()
+        .args(["status", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    let stale = json["stale"].as_array().unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0]["name"], "stale_spec");
+    assert!(stale[0]["path"].as_str().unwrap().contains("stale_spec.md"));
+}
+
+#[test]
+fn status_without_json_flag_outputs_text() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "draft",
+        None,
+    );
+
+    specre()
+        .args(["status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Status Summary:"));
+}
+
+// ============================================================
+// trace --json (ULID lookup)
+// ============================================================
+
+#[test]
+fn trace_json_ulid_lookup() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some("2026-02-15"),
+    );
+    write_source(tmp.path(), "src/main.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+
+    let assert = specre()
+        .args(["trace", "--json", "01AAAAAAAAAAAAAAAAAAAAAAAA"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(json["specre"].as_str().unwrap().contains("spec_a.md"));
+    let refs = json["source_refs"].as_array().unwrap();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0]["file"], "src/main.rs");
+    assert_eq!(refs[0]["line"], 1);
+}
+
+#[test]
+fn trace_json_file_lookup() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some("2026-02-15"),
+    );
+    write_source(tmp.path(), "src/main.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+
+    let assert = specre()
+        .args(["trace", "--json", "src/main.rs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["file"], "src/main.rs");
+    let specres = json["specres"].as_array().unwrap();
+    assert_eq!(specres.len(), 1);
+    assert_eq!(specres[0]["id"], "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    assert!(specres[0]["path"].as_str().unwrap().contains("spec_a.md"));
+}
+
+#[test]
+fn trace_json_unknown_ulid() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    let assert = specre()
+        .args(["trace", "--json", "01ZZZZZZZZZZZZZZZZZZZZZZZZ"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure();
+
+    let json = parse_json(&assert);
+    assert!(json["specre"].is_null());
+    assert!(json["source_refs"].as_array().unwrap().is_empty());
+}
+
+// ============================================================
+// orphans --json
+// ============================================================
+
+#[test]
+fn orphans_json_with_orphans() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    // Orphan specre: no source marker
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/orphan_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "orphan_spec",
+        "stable",
+        Some("2026-02-15"),
+    );
+    // Dangling marker: marker with no matching specre
+    write_source(tmp.path(), "src/main.rs", "01ZZZZZZZZZZZZZZZZZZZZZZZZ");
+
+    let assert = specre()
+        .args(["orphans", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure();
+
+    let json = parse_json(&assert);
+    let orphan_specres = json["orphan_specres"].as_array().unwrap();
+    assert_eq!(orphan_specres.len(), 1);
+    assert!(orphan_specres[0].as_str().unwrap().contains("orphan_spec.md"));
+
+    let dangling = json["dangling_markers"].as_array().unwrap();
+    assert_eq!(dangling.len(), 1);
+    assert_eq!(dangling[0]["file"], "src/main.rs");
+    assert_eq!(dangling[0]["id"], "01ZZZZZZZZZZZZZZZZZZZZZZZZ");
+}
+
+#[test]
+fn orphans_json_no_orphans() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some("2026-02-15"),
+    );
+    write_source(tmp.path(), "src/main.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+
+    let assert = specre()
+        .args(["orphans", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(json["orphan_specres"].as_array().unwrap().is_empty());
+    assert!(json["dangling_markers"].as_array().unwrap().is_empty());
+}
+
+// ============================================================
+// coverage --json
+// ============================================================
+
+#[test]
+fn coverage_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_source(tmp.path(), "src/tagged.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    write_source_no_marker(tmp.path(), "src/untagged.rs");
+
+    let assert = specre()
+        .args(["coverage", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["total"], 2);
+    assert_eq!(json["tagged"], 1);
+    assert_eq!(json["coverage"], 0.5);
+    let uncovered = json["uncovered"].as_array().unwrap();
+    assert_eq!(uncovered.len(), 1);
+    assert_eq!(uncovered[0], "src/untagged.rs");
+}
+
+#[test]
+fn coverage_json_with_ext_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_source(tmp.path(), "src/tagged.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    write_source_no_marker(tmp.path(), "src/other.ts");
+
+    let assert = specre()
+        .args(["coverage", "--json", "--ext", "rs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["tagged"], 1);
+}
+
+// ============================================================
+// init --json
+// ============================================================
+
+#[test]
+fn init_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+
+    let assert = specre()
+        .args(["init", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["specre_dir"], "docs/specres");
+    assert_eq!(json["config_file"], "specre.toml");
+
+    // Verify files were actually created
+    assert!(tmp.path().join("specre.toml").exists());
+    assert!(tmp.path().join("docs/specres").exists());
+}
+
+// ============================================================
+// new --json
+// ============================================================
+
+#[test]
+fn new_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+    // new doesn't require specre.toml, but load_language() tries to read it
+    fs::create_dir_all(tmp.path().join("docs/specres/cli")).unwrap();
+
+    let assert = specre()
+        .args(["new", "docs/specres/cli", "--name", "test_spec", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(json["id"].is_string());
+    assert_eq!(json["id"].as_str().unwrap().len(), 26); // ULID length
+    let path = json["path"].as_str().unwrap();
+    assert!(path.contains("test_spec.md"));
+}
+
+// ============================================================
+// tag --json
+// ============================================================
+
+#[test]
+fn tag_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+    write_source_no_marker(tmp.path(), "src/main.rs");
+
+    let assert = specre()
+        .args([
+            "tag",
+            "--json",
+            "01AAAAAAAAAAAAAAAAAAAAAAAA",
+            "src/main.rs",
+        ])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["id"], "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    assert_eq!(json["file"], "src/main.rs");
+    assert_eq!(json["line"], 1);
+}
+
+// ============================================================
+// index --json
+// ============================================================
+
+#[test]
+fn index_json_outputs_structured_json() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+        Some("2026-02-15"),
+    );
+    write_source(tmp.path(), "src/main.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+
+    let assert = specre()
+        .args(["index", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["index_file"], "index.json");
+    assert_eq!(json["specre_count"], 1);
+    assert_eq!(json["source_ref_count"], 1);
+    let md_files = json["index_md_files"].as_array().unwrap();
+    assert_eq!(md_files.len(), 1);
+    assert!(md_files[0].as_str().unwrap().contains("INDEX.md"));
+}
+
+// ============================================================
+// search --json (already JSON, flag accepted)
+// ============================================================
+
+#[test]
+fn search_json_flag_accepted() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+
+    let assert = specre()
+        .args(["search", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(json["results"].is_array());
+    assert!(json["total"].is_number());
+}
+
+// ============================================================
+// health-check --json (already JSON, flag accepted)
+// ============================================================
+
+#[test]
+fn health_check_json_flag_accepted() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    // health-check will likely fail (no index.json) but we just want to confirm
+    // the --json flag is accepted without error
+    specre()
+        .args(["health-check", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .stderr(predicate::str::contains("unrecognized").not());
+}
+
+// ============================================================
+// --json flag placement (global flag)
+// ============================================================
+
+#[test]
+fn json_flag_before_subcommand() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+
+    let assert = specre()
+        .args(["--json", "status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(json["summary"].is_object());
+}
+
+// ============================================================
+// Error output goes to stderr regardless of --json
+// ============================================================
+
+#[test]
+fn json_error_goes_to_stderr_as_plain_text() {
+    let tmp = TempDir::new().unwrap();
+    // No specre.toml
+
+    specre()
+        .args(["status", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "specre.toml not found. Run 'specre init' first.",
+        ));
+}


### PR DESCRIPTION
## Summary

- Add a global `--json` flag to the top-level CLI struct, available across all subcommands
- Implement structured JSON output for 8 commands: `status`, `trace`, `orphans`, `coverage`, `init`, `new`, `tag`, `index`
- Commands that already output JSON (`search`, `health-check`) accept the flag without changing behavior
- Error messages remain plain text on stderr regardless of `--json`

Roadmap item: v0.3 Agent Integration — "Agent-friendly output formats across all commands (`--json`, `--md`)"

## Test plan

- [x] 18 new integration tests in `tests/cli_json_output.rs` covering all commands
- [x] All 218 existing tests continue to pass (backward compatibility preserved)
- [x] Verified `--json` flag works both before and after subcommand (`specre --json status` and `specre status --json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)