### PR TITLE
docs: remove --md from roadmap, mark --json as completed

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -20,7 +20,7 @@ Enable AI agents to utilize specre as a first-class tool.
 - [x] `specre coverage` — Report the percentage of source files covered by specre tags
 - [x] `specre health-check` — Comprehensive health check to determine whether specre cards adequately describe the project's overall behavior
 - [x] `specre search <query>` — Full-text + status/domain filtering across all specres, with JSON output for agent consumption
-- [ ] Agent-friendly output formats across all commands (`--json`, `--md`)
+- [x] Agent-friendly output formats across all commands (`--json`)
 - [ ] MCP server — Expose specre capabilities as Resources, Tools, and Prompts via the [Model Context Protocol](https://modelcontextprotocol.io/), enabling integration with Claude Code, Cursor, VS Code Copilot, and other MCP-compatible AI tools
 
 ### Coverage command design


### PR DESCRIPTION
## Summary

- Remove `--md` output format from the v0.3 roadmap item — markdown output across all commands lacks concrete use cases for both human users and AI agents
- Mark `--json` agent-friendly output as completed (`[x]`)
- JSON serves as the data layer; presentation formatting is the consumer's responsibility (CI, IDE, agents)

## Rationale

Markdown output for individual CLI commands provides no clear benefit over:
- **For agents:** `--json` (structured, parseable)
- **For humans in terminal:** default text output (already readable)
- **For reports/PRs:** JSON can be transformed by CI scripts with full formatting control

Specific markdown outputs (e.g., `INDEX.md`, `specre export --format md`) remain planned where they serve a concrete purpose.

## Test plan

- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)