### PR TITLE
fix: move index.json to specre_dir, rename INDEX.md to _INDEX.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The marker can be placed at the top of a file, above a class or function definit
 
 ## Index Format
 
-`specre index` scans the specification directory and source tree to generate `index.json` — a machine-readable cache for fast lookups.
+`specre index` scans the specification directory and source tree to generate `index.json` inside `specre_dir` — a machine-readable cache for fast lookups.
 
 ```json
 {
@@ -309,7 +309,7 @@ Each entry records a `@specre` marker found in the source tree:
 
 - **index.json is a cache, not a source of truth.** If it's missing or stale, run `specre index` to regenerate. Never edit it manually.
 - **specre files are the source of truth.** All authoritative data lives in the front-matter and body of each `.md` file.
-- **Per-directory INDEX.md** can also be generated for human browsing — a Markdown table summarizing all specres in a subdirectory.
+- **Per-directory _INDEX.md** can also be generated for human browsing — a Markdown table summarizing all specres in a subdirectory.
 
 ## Comparison with Other Tools
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - [x] `specre init` — Initialize specre in a project, creating the specre directory and configuration file
 - [x] `specre new` — Scaffold a new specre from a template, auto-generating a ULID for the `id` field
-- [x] `specre index` — Scan specre directory and source tree; generate `index.json` and per-domain `INDEX.md`
+- [x] `specre index` — Scan specre directory and source tree; generate `index.json` and per-domain `_INDEX.md`
 - [x] `specre status` — Report specre counts by status and flag stale `last_verified` dates
 
 ## v0.2 — Traceability ✅

--- a/docs/specres/cli/_INDEX.md
+++ b/docs/specres/cli/_INDEX.md
@@ -4,7 +4,7 @@
 |------|--------|---------------|
 | [specre_new_scaffolds_a_new_specre](specre_new_scaffolds_a_new_specre.md) | stable | 2026-02-13 |
 | [specre_init_initializes_project_configuration](specre_init_initializes_project_configuration.md) | stable | 2026-02-13 |
-| [specre_index_generates_project_index](specre_index_generates_project_index.md) | stable | 2026-02-13 |
+| [specre_index_generates_project_index](specre_index_generates_project_index.md) | stable | 2026-02-15 |
 | [specre_status_reports_project_health](specre_status_reports_project_health.md) | stable | 2026-02-13 |
 | [specre_trace_resolves_bidirectional_references](specre_trace_resolves_bidirectional_references.md) | stable | 2026-02-13 |
 | [specre_orphans_detects_unlinked_specres_and_markers](specre_orphans_detects_unlinked_specres_and_markers.md) | stable | 2026-02-13 |

--- a/docs/specres/cli/specre_index_generates_project_index.md
+++ b/docs/specres/cli/specre_index_generates_project_index.md
@@ -2,7 +2,7 @@
 id: "01KHAKAYN5WPTDVR99D5Q5TMJE"
 name: "specre_index_generates_project_index"
 status: "stable"
-last_verified: "2026-02-13"
+last_verified: "2026-02-15"
 ---
 
 ## Related Files
@@ -13,13 +13,13 @@ last_verified: "2026-02-13"
 
 ## Functional Overview
 
-`specre index` scans the specre directory and source tree, then generates `index.json` (a machine-readable cache) at the project root and per-domain `INDEX.md` files (human-readable summaries) in each domain directory. It reads `specre.toml` to determine the specre directory and source directories.
+`specre index` scans the specre directory and source tree, then generates `index.json` (a machine-readable cache) inside `specre_dir` and per-domain `_INDEX.md` files (human-readable summaries) in each domain directory. It reads `specre.toml` to determine the specre directory and source directories.
 
 ## Design Intent
 
 The index command produces a derived artifact that other commands and external tools can consume for fast lookups without re-parsing every specre file. `index.json` is a cache — it can be regenerated at any time and should never be edited manually.
 
-Per-domain `INDEX.md` files provide a browsable overview of all specres in a domain, useful for both human developers and AI agents navigating the specification tree.
+Per-domain `_INDEX.md` files provide a browsable overview of all specres in a domain, useful for both human developers and AI agents navigating the specification tree.
 
 ## Key Members
 
@@ -36,8 +36,8 @@ Per-domain `INDEX.md` files provide a browsable overview of all specres in a dom
 2. CLI reads `specre.toml` to determine `specre_dir` and `source_dirs`
 3. CLI scans all `.md` files under `specre_dir` recursively, parsing YAML front-matter
 4. CLI scans files under `source_dirs` recursively for `@specre <ULID>` markers (filtered by `target_extensions` if set)
-5. CLI writes `index.json` at the project root with `version`, `generated_at`, `specres`, and `source_refs`
-6. CLI prints a summary to stdout: `Generated index.json (N specres, M source refs)`
+5. CLI writes `index.json` inside `specre_dir` (e.g., `docs/specres/index.json`) with `version`, `generated_at`, `specres`, and `source_refs`
+6. CLI prints a summary to stdout: `Generated <specre_dir>/index.json (N specres, M source refs)`
 
 ### specres array contains correct entries
 
@@ -54,13 +54,13 @@ Per-domain `INDEX.md` files provide a browsable overview of all specres in a dom
 4. Markers inside string literals are ignored: if a quote character (`"` or `'`) appears before `@specre` on the same line, the marker is not detected
 5. When `target_extensions` is set in `specre.toml`, only files whose extension matches the list are scanned. When unset, all files are scanned.
 
-### Per-domain INDEX.md is generated
+### Per-domain _INDEX.md is generated
 
-1. For each domain directory (top-level directory under `specre_dir`), CLI generates an `INDEX.md` in that domain directory
-2. `INDEX.md` contains a Markdown table with columns: Name, Status, Last Verified
+1. For each domain directory (top-level directory under `specre_dir`), CLI generates an `_INDEX.md` in that domain directory
+2. `_INDEX.md` contains a Markdown table with columns: Name, Status, Last Verified
 3. Name column links to the specre file using a path relative to the domain directory (e.g., `[user_can_sign_up](signup/user_can_sign_up.md)` for a specre nested in a subdirectory)
-4. `INDEX.md` includes all specres within the domain, including those in subdirectories
-5. CLI prints each generated `INDEX.md` path to stdout
+4. `_INDEX.md` includes all specres within the domain, including those in subdirectories
+5. CLI prints each generated `_INDEX.md` path to stdout
 
 ### Subdirectories within a domain are handled correctly
 
@@ -71,7 +71,7 @@ Per-domain `INDEX.md` files provide a browsable overview of all specres in a dom
      password/user_can_reset_password.md
      system_rejects_expired_token.md
    ```
-2. `specre index` produces one `INDEX.md` at `docs/specres/auth/INDEX.md`
+2. `specre index` produces one `_INDEX.md` at `docs/specres/auth/_INDEX.md`
 3. All three specres appear in the table, with paths relative to the domain directory:
    - `signup/user_can_sign_up.md`
    - `password/user_can_reset_password.md`
@@ -87,11 +87,11 @@ Per-domain `INDEX.md` files provide a browsable overview of all specres in a dom
 
 1. User runs `specre index` with a valid `specre.toml` but no specre files exist
 2. CLI generates `index.json` with empty `specres` and `source_refs` arrays
-3. No `INDEX.md` files are generated
+3. No `_INDEX.md` files are generated
 
 ### Overwrites existing index files
 
-1. User runs `specre index` when `index.json` and `INDEX.md` already exist
+1. User runs `specre index` when `index.json` and `_INDEX.md` already exist
 2. CLI overwrites both files with fresh content
 3. No error is raised
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-15T06:49:27Z",
+  "generated_at": "2026-02-15T07:37:20Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -24,7 +24,7 @@
       "status": "stable",
       "domain": "cli",
       "path": "docs/specres/cli/specre_index_generates_project_index.md",
-      "last_verified": "2026-02-13"
+      "last_verified": "2026-02-15"
     },
     {
       "id": "01KHAN6JE712ZAKXPP97854PKJ",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub enum Commands {
     /// Create a new specre card from a template
     New(NewArgs),
 
-    /// Generate index.json and per-domain INDEX.md
+    /// Generate index.json and per-domain _INDEX.md
     Index,
 
     /// Report specre counts by status and flag stale last_verified dates

--- a/src/commands/health_check.rs
+++ b/src/commands/health_check.rs
@@ -22,8 +22,9 @@ struct Thresholds {
     index_age_hours: f64,
 }
 
-fn get_index_age_hours() -> Option<f64> {
-    let content = fs::read_to_string("index.json").ok()?;
+fn get_index_age_hours(specre_dir: &str) -> Option<f64> {
+    let index_path = std::path::Path::new(specre_dir).join("index.json");
+    let content = fs::read_to_string(index_path).ok()?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
     let generated_at = parsed["generated_at"].as_str()?;
     let generated =
@@ -57,7 +58,7 @@ pub fn execute() -> Result<(), String> {
     let orphan_count = orphan_result.orphan_specres + orphan_result.dangling_markers;
 
     // Index freshness
-    let index_age_hours = get_index_age_hours();
+    let index_age_hours = get_index_age_hours(&cfg.specre_dir);
 
     // Healthy check
     let coverage_ok = coverage_ratio >= threshold_coverage;

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -58,15 +58,18 @@ pub fn execute(json_flag: bool) -> Result<(), String> {
         source_refs,
     };
 
+    let index_json_path = specre_dir.join("index.json");
+    let index_json_rel = format!("{}/index.json", config.specre_dir);
     let json =
         serde_json::to_string_pretty(&index).map_err(|e| format!("Failed to serialize: {e}"))?;
-    fs::write("index.json", &json).map_err(|e| format!("Failed to write index.json: {e}"))?;
+    fs::write(&index_json_path, &json)
+        .map_err(|e| format!("Failed to write {index_json_rel}: {e}"))?;
 
     let index_md_files = generate_index_md(specre_dir, &config.specre_dir, &index.specres)?;
 
     if json_flag {
         let output = IndexOutput {
-            index_file: "index.json".to_string(),
+            index_file: index_json_rel,
             specre_count: index.specres.len(),
             source_ref_count: index.source_refs.len(),
             index_md_files,
@@ -76,7 +79,7 @@ pub fn execute(json_flag: bool) -> Result<(), String> {
         println!("{json_str}");
     } else {
         println!(
-            "Generated index.json ({} specres, {} source refs)",
+            "Generated {index_json_rel} ({} specres, {} source refs)",
             index.specres.len(),
             index.source_refs.len()
         );
@@ -145,8 +148,8 @@ pub fn collect_md_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
             }
             collect_md_files(&path, cb);
         } else if path.extension().is_some_and(|ext| ext == "md") {
-            // Skip INDEX.md files
-            if path.file_name().is_some_and(|n| n == "INDEX.md") {
+            // Skip _INDEX.md files
+            if path.file_name().is_some_and(|n| n == "_INDEX.md") {
                 continue;
             }
             cb(&path);
@@ -330,7 +333,7 @@ fn generate_index_md(
 
     for (domain, entries) in &by_domain {
         let domain_dir = specre_dir.join(domain);
-        let index_path = domain_dir.join("INDEX.md");
+        let index_path = domain_dir.join("_INDEX.md");
         let domain_prefix = format!("{prefix}{domain}/");
 
         let mut md = format!(
@@ -354,7 +357,7 @@ fn generate_index_md(
             .map_err(|e| format!("Failed to write '{}': {e}", index_path.display()))?;
 
         let index_rel =
-            to_forward_slash(&PathBuf::from(specre_dir_str).join(domain).join("INDEX.md"));
+            to_forward_slash(&PathBuf::from(specre_dir_str).join(domain).join("_INDEX.md"));
         generated_files.push(index_rel);
     }
 

--- a/tests/cli_health_check.rs
+++ b/tests/cli_health_check.rs
@@ -52,7 +52,9 @@ fn write_index_json(dir: &std::path::Path, generated_at: &str) {
     let content = format!(
         r#"{{"version":1,"generated_at":"{generated_at}","specres":[],"source_refs":[]}}"#
     );
-    fs::write(dir.join("index.json"), content).unwrap();
+    let path = dir.join("docs/specres/index.json");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
 }
 
 fn recent_timestamp() -> String {
@@ -461,7 +463,7 @@ fn health_check_malformed_index_json() {
     );
 
     // Malformed index.json
-    fs::write(tmp.path().join("index.json"), "not valid json").unwrap();
+    fs::write(tmp.path().join("docs/specres/index.json"), "not valid json").unwrap();
 
     let output = specre()
         .args(["health-check"])

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -81,9 +81,9 @@ fn index_generates_index_json() {
         .current_dir(tmp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Generated index.json"));
+        .stdout(predicate::str::contains("Generated docs/specres/index.json"));
 
-    assert!(tmp.path().join("index.json").is_file());
+    assert!(tmp.path().join("docs/specres/index.json").is_file());
 }
 
 // -- Scenario: specres array contains correct entries --
@@ -107,7 +107,7 @@ fn index_json_contains_specre_entries() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     assert_eq!(json["version"], 1);
@@ -151,7 +151,7 @@ fn index_json_contains_source_refs() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();
@@ -178,7 +178,7 @@ fn index_detects_multiple_markers_in_one_file() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();
@@ -207,9 +207,9 @@ fn index_generates_domain_index_md() {
         .current_dir(tmp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("docs/specres/auth/INDEX.md"));
+        .stdout(predicate::str::contains("docs/specres/auth/_INDEX.md"));
 
-    let index_md = fs::read_to_string(tmp.path().join("docs/specres/auth/INDEX.md")).unwrap();
+    let index_md = fs::read_to_string(tmp.path().join("docs/specres/auth/_INDEX.md")).unwrap();
     assert!(index_md.contains("| Name |"));
     assert!(index_md.contains("user_can_sign_up"));
     assert!(index_md.contains("stable"));
@@ -253,7 +253,7 @@ fn index_handles_subdirectories_within_domain() {
         .success();
 
     // All three should have domain "auth"
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
     let specres = json["specres"].as_array().unwrap();
     assert_eq!(specres.len(), 3);
@@ -261,22 +261,22 @@ fn index_handles_subdirectories_within_domain() {
         assert_eq!(entry["domain"], "auth");
     }
 
-    // INDEX.md should be at domain level only
-    let index_md = fs::read_to_string(tmp.path().join("docs/specres/auth/INDEX.md")).unwrap();
+    // _INDEX.md should be at domain level only
+    let index_md = fs::read_to_string(tmp.path().join("docs/specres/auth/_INDEX.md")).unwrap();
     // Links should use paths relative to domain directory
     assert!(index_md.contains("signup/user_can_sign_up.md"));
     assert!(index_md.contains("password/user_can_reset_password.md"));
     assert!(index_md.contains("system_rejects_expired_token.md"));
 
-    // No INDEX.md in subdirectories
+    // No _INDEX.md in subdirectories
     assert!(
         !tmp.path()
-            .join("docs/specres/auth/signup/INDEX.md")
+            .join("docs/specres/auth/signup/_INDEX.md")
             .exists()
     );
     assert!(
         !tmp.path()
-            .join("docs/specres/auth/password/INDEX.md")
+            .join("docs/specres/auth/password/_INDEX.md")
             .exists()
     );
 }
@@ -311,7 +311,7 @@ fn index_handles_empty_specre_dir() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
     assert_eq!(json["specres"].as_array().unwrap().len(), 0);
     assert_eq!(json["source_refs"].as_array().unwrap().len(), 0);
@@ -332,8 +332,8 @@ fn index_overwrites_existing_index() {
         None,
     );
 
-    // Write stale index.json
-    fs::write(tmp.path().join("index.json"), "old content").unwrap();
+    // Write stale index.json in specre_dir
+    fs::write(tmp.path().join("docs/specres/index.json"), "old content").unwrap();
 
     specre()
         .args(["index"])
@@ -341,7 +341,7 @@ fn index_overwrites_existing_index() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     assert_ne!(json_str, "old content");
     // Verify it's valid JSON
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
@@ -369,7 +369,7 @@ fn index_json_last_verified_is_null_when_absent() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
     let entry = &json["specres"][0];
     assert!(entry["last_verified"].is_null());
@@ -401,7 +401,7 @@ fn index_json_paths_use_forward_slashes() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     // No backslashes in paths
     assert!(!json_str.contains('\\'));
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
@@ -440,7 +440,7 @@ fn index_ignores_markers_inside_string_literals() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();
@@ -483,7 +483,7 @@ fn index_target_extensions_filters_source_files() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();
@@ -516,7 +516,7 @@ fn index_empty_target_extensions_scans_nothing() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();
@@ -554,7 +554,7 @@ fn index_without_target_extensions_scans_all_files() {
         .assert()
         .success();
 
-    let json_str = fs::read_to_string(tmp.path().join("index.json")).unwrap();
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
     let refs = json["source_refs"].as_array().unwrap();

--- a/tests/cli_json_output.rs
+++ b/tests/cli_json_output.rs
@@ -440,12 +440,12 @@ fn index_json_outputs_structured_json() {
         .success();
 
     let json = parse_json(&assert);
-    assert_eq!(json["index_file"], "index.json");
+    assert_eq!(json["index_file"], "docs/specres/index.json");
     assert_eq!(json["specre_count"], 1);
     assert_eq!(json["source_ref_count"], 1);
     let md_files = json["index_md_files"].as_array().unwrap();
     assert_eq!(md_files.len(), 1);
-    assert!(md_files[0].as_str().unwrap().contains("INDEX.md"));
+    assert!(md_files[0].as_str().unwrap().contains("_INDEX.md"));
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Move `index.json` output from project root to `specre_dir` (e.g., `docs/specres/index.json`) to avoid naming conflicts and keep derived artifacts within the specre tree
- Rename `INDEX.md` to `_INDEX.md` so it sorts to the top of directory listings in file explorers
- Update `health-check` command to read `index.json` from `specre_dir`

## Test plan

- [x] All 198 existing tests pass
- [x] `index.json` is generated inside `specre_dir` instead of project root
- [x] `_INDEX.md` is generated per domain with underscore prefix
- [x] `health-check` reads `index.json` from the new location
- [x] `--json` output reflects new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)