### PR TITLE
chore: enable strict clippy lints (pedantic + nursery + all)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,15 @@ assert_cmd = "2"
 assert_fs = "1"
 predicates = "3"
 
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+all = { level = "deny", priority = -1 }
+# allow specre::config::Config etc.
+module_name_repetitions = "allow"
+# percentage computation from file counts inherently requires usize/i64 → f64 casts
+cast_precision_loss = "allow"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/src/card.rs
+++ b/src/card.rs
@@ -29,6 +29,7 @@ pub struct SpecreCard {
 ///
 /// On Windows, backslashes are replaced with forward slashes.
 /// On Unix, the path string is returned as-is.
+#[must_use]
 pub fn to_forward_slash(path: &Path) -> Cow<'_, str> {
     let s = path.to_string_lossy();
     if s.contains('\\') {
@@ -44,6 +45,7 @@ pub fn to_forward_slash(path: &Path) -> Cow<'_, str> {
 /// ```text
 /// extract_domain("docs/specres/cli/foo.md", "docs/specres") => "cli"
 /// ```
+#[must_use]
 pub fn extract_domain<'a>(rel_path: &'a str, specre_dir: &str) -> &'a str {
     let prefix = if specre_dir.ends_with('/') {
         specre_dir.to_string()
@@ -58,6 +60,7 @@ pub fn extract_domain<'a>(rel_path: &'a str, specre_dir: &str) -> &'a str {
 ///
 /// Cards are sorted by ID. Files with malformed front-matter are
 /// skipped with a warning printed to stderr.
+#[must_use]
 pub fn scan_specre_cards(specre_dir: &Path, specre_dir_str: &str) -> Vec<SpecreCard> {
     let mut cards = Vec::new();
     if !specre_dir.exists() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub enum Commands {
     /// Generate index.json and per-domain _INDEX.md
     Index,
 
-    /// Report specre counts by status and flag stale last_verified dates
+    /// Report specre counts by status and flag stale `last_verified` dates
     Status(StatusArgs),
 
     /// Bidirectional traceability lookup by ULID or file path
@@ -61,15 +61,15 @@ pub struct SearchArgs {
     #[arg(long)]
     pub status: Option<String>,
 
-    /// Filter by domain (top-level directory under specre_dir)
+    /// Filter by domain (top-level directory under `specre_dir`)
     #[arg(long)]
     pub domain: Option<String>,
 
-    /// Include only specres whose last_verified is before this date (YYYY-MM-DD)
+    /// Include only specres whose `last_verified` is before this date (YYYY-MM-DD)
     #[arg(long)]
     pub verified_before: Option<String>,
 
-    /// Include only specres whose last_verified is on or after this date (YYYY-MM-DD)
+    /// Include only specres whose `last_verified` is on or after this date (YYYY-MM-DD)
     #[arg(long)]
     pub verified_after: Option<String>,
 
@@ -99,7 +99,7 @@ pub struct InitArgs {
 
 #[derive(Args)]
 pub struct StatusArgs {
-    /// Number of days after which a stable specre's last_verified is considered stale
+    /// Number of days after which a stable specre's `last_verified` is considered stale
     #[arg(long, default_value_t = 30)]
     pub threshold: u32,
 }

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -20,7 +20,8 @@ pub struct CoverageResult {
     pub uncovered: Vec<String>,
 }
 
-/// Derives a `CoverageResult` from a pre-computed `SourceScanResult`.
+/// Derives a [`CoverageResult`] from a pre-computed [`SourceScanResult`].
+#[must_use]
 pub fn coverage_from_scan(scan: &SourceScanResult) -> CoverageResult {
     CoverageResult {
         total: scan.total,
@@ -29,6 +30,7 @@ pub fn coverage_from_scan(scan: &SourceScanResult) -> CoverageResult {
     }
 }
 
+#[must_use]
 pub fn compute_coverage(
     source_dirs: &[String],
     target_extensions: Option<&[String]>,
@@ -37,6 +39,9 @@ pub fn compute_coverage(
     coverage_from_scan(&scan)
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on config or serialization failure.
 pub fn execute(args: CoverageArgs, json: bool) -> Result<(), SpecreError> {
     let config = config::load()?;
 
@@ -65,7 +70,10 @@ pub fn execute(args: CoverageArgs, json: bool) -> Result<(), SpecreError> {
             println!("Coverage: 0/0 files (N/A)");
         } else {
             let pct = result.tagged as f64 / result.total as f64 * 100.0;
-            println!("Coverage: {}/{} files ({:.1}%)", result.tagged, result.total, pct);
+            println!(
+                "Coverage: {}/{} files ({:.1}%)",
+                result.tagged, result.total, pct
+            );
         }
 
         if !result.uncovered.is_empty() {

--- a/src/commands/health_check.rs
+++ b/src/commands/health_check.rs
@@ -64,6 +64,10 @@ fn get_index_age_hours(specre_dir: &str) -> Option<f64> {
     Some((hours * 10.0).round() / 10.0)
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on config or serialization failure, or
+/// [`SpecreError::NonZeroExit`] when health checks fail.
 pub fn execute() -> Result<(), SpecreError> {
     let cfg = config::load()?;
 
@@ -94,9 +98,7 @@ pub fn execute() -> Result<(), SpecreError> {
     // Healthy check
     let coverage_ok = coverage_ratio >= threshold_coverage;
     let orphans_ok = orphan_count <= threshold_orphans;
-    let index_ok = index_age_hours
-        .map(|age| age <= threshold_index_age)
-        .unwrap_or(false);
+    let index_ok = index_age_hours.is_some_and(|age| age <= threshold_index_age);
     let healthy = coverage_ok && orphans_ok && index_ok;
 
     let result = HealthCheckResult {

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -8,6 +8,7 @@ use crate::scanner::collect_all_files;
 use chrono::Utc;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -35,6 +36,9 @@ struct SourceRef {
     line: usize,
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on config, I/O, or serialization failure.
 pub fn execute(json_flag: bool) -> Result<(), SpecreError> {
     let config = config::load()?;
 
@@ -154,10 +158,11 @@ fn generate_index_md(
                 .unwrap_or(&entry.path);
             let display_name = &entry.name;
             let last_verified = entry.last_verified.as_deref().unwrap_or("-");
-            md.push_str(&format!(
-                "| [{display_name}]({rel_to_domain}) | {} | {last_verified} |\n",
+            let _ = writeln!(
+                md,
+                "| [{display_name}]({rel_to_domain}) | {} | {last_verified} |",
                 entry.status
-            ));
+            );
         }
 
         fs::write(&index_path, &md).map_err(|e| SpecreError::Io {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -25,6 +25,9 @@ struct InitOutput {
 
 const CONFIG_FILE: &str = "specre.toml";
 
+/// # Errors
+///
+/// Returns [`SpecreError`] if already initialized, or on I/O / serialization failure.
 pub fn execute(args: InitArgs, json: bool) -> Result<(), SpecreError> {
     let config_path = Path::new(CONFIG_FILE);
 

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -8,7 +8,11 @@ use crate::{template, ulid};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::*,
+    model::{
+        AnnotateAble, CallToolResult, Content, Implementation, ListResourcesResult,
+        PaginatedRequestParams, ProtocolVersion, RawResource, ReadResourceRequestParams,
+        ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
+    },
     schemars, tool, tool_handler, tool_router,
     service::RequestContext,
     transport::stdio,
@@ -22,7 +26,7 @@ const URI_PREFIX: &str = "specre:///";
 #[derive(Clone)]
 pub struct SpecreMcpServer {
     specre_dir: PathBuf,
-    tool_router: ToolRouter<SpecreMcpServer>,
+    tool_router: ToolRouter<Self>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -43,6 +47,7 @@ impl SpecreMcpServer {
     }
 
     #[tool(name = "new", description = "Create a new specre card from a template, auto-generating a ULID")]
+    #[allow(clippy::unused_self)] // &self required by rmcp #[tool] macro
     fn new_card(
         &self,
         Parameters(req): Parameters<NewToolRequest>,
@@ -189,6 +194,9 @@ impl ServerHandler for SpecreMcpServer {
     }
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on runtime creation, MCP init, or server failure.
 pub fn execute() -> Result<(), crate::error::SpecreError> {
     let rt = tokio::runtime::Runtime::new().map_err(crate::error::SpecreError::TokioRuntime)?;
     rt.block_on(run_server())

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -17,7 +17,10 @@ struct NewOutput {
     path: String,
 }
 
-pub fn execute(args: NewArgs, json: bool) -> Result<(), SpecreError> {
+/// # Errors
+///
+/// Returns [`SpecreError`] on invalid arguments, I/O, or serialization failure.
+pub fn execute(args: &NewArgs, json: bool) -> Result<(), SpecreError> {
     let target = Path::new(&args.target_dir);
 
     if target.is_file() {

--- a/src/commands/orphans.rs
+++ b/src/commands/orphans.rs
@@ -24,16 +24,19 @@ pub struct OrphanResult {
 }
 
 impl OrphanResult {
-    pub fn orphan_count(&self) -> usize {
+    #[must_use]
+    pub const fn orphan_count(&self) -> usize {
         self.orphan_specres.len()
     }
 
-    pub fn dangling_count(&self) -> usize {
+    #[must_use]
+    pub const fn dangling_count(&self) -> usize {
         self.dangling_markers.len()
     }
 }
 
-/// Derives an `OrphanResult` from a pre-computed `SourceScanResult`.
+/// Derives an [`OrphanResult`] from a pre-computed [`SourceScanResult`].
+#[must_use]
 pub fn orphans_from_scan(specre_dir: &str, scan: &SourceScanResult) -> OrphanResult {
     let specre_dir_path = Path::new(specre_dir);
     let cards = card::scan_specre_cards(specre_dir_path, specre_dir);
@@ -69,6 +72,7 @@ pub fn orphans_from_scan(specre_dir: &str, scan: &SourceScanResult) -> OrphanRes
     }
 }
 
+#[must_use]
 pub fn compute_orphans(
     specre_dir: &str,
     source_dirs: &[String],
@@ -78,6 +82,10 @@ pub fn compute_orphans(
     orphans_from_scan(specre_dir, &scan)
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on config or serialization failure, or
+/// [`SpecreError::NonZeroExit`] when orphans or dangling markers are detected.
 pub fn execute(json: bool) -> Result<(), SpecreError> {
     let config = config::load()?;
     let result = compute_orphans(

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -52,7 +52,10 @@ struct SearchableCard {
     excerpt: Option<String>,
 }
 
-pub fn execute(args: SearchArgs) -> Result<(), SpecreError> {
+/// # Errors
+///
+/// Returns [`SpecreError`] on invalid arguments, config, or serialization failure.
+pub fn execute(args: &SearchArgs) -> Result<(), SpecreError> {
     // Validate inputs
     let status_filter: Option<Status> = match &args.status {
         Some(s) => Some(
@@ -270,14 +273,11 @@ fn skip_frontmatter(content: &str) -> &str {
         return content;
     }
     let after_first = &content[3..];
-    match after_first.find("\n---") {
-        Some(end) => {
-            let rest = &after_first[end + 4..];
-            // Skip the newline after closing ---
-            rest.strip_prefix('\n').unwrap_or(rest)
-        }
-        None => content,
-    }
+    after_first.find("\n---").map_or(content, |end| {
+        let rest = &after_first[end + 4..];
+        // Skip the newline after closing ---
+        rest.strip_prefix('\n').unwrap_or(rest)
+    })
 }
 
 fn card_to_result(card: SearchableCard) -> SearchResult {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -34,7 +34,10 @@ struct StaleEntry {
     reason: String,
 }
 
-pub fn execute(args: StatusArgs, json: bool) -> Result<(), SpecreError> {
+/// # Errors
+///
+/// Returns [`SpecreError`] on config or serialization failure.
+pub fn execute(args: &StatusArgs, json: bool) -> Result<(), SpecreError> {
     let config = config::load()?;
     let specre_dir = Path::new(&config.specre_dir);
 
@@ -62,27 +65,28 @@ pub fn execute(args: StatusArgs, json: bool) -> Result<(), SpecreError> {
                     Status::InDevelopment => in_development += 1,
                     Status::Stable => {
                         stable += 1;
-                        let reason = match &fm.last_verified {
-                            None => Some("no last_verified".to_string()),
-                            Some(date_str) => match NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
-                            {
-                                Ok(date) => {
-                                    let days = (today - date).num_days();
-                                    if days > threshold as i64 {
-                                        Some(format!("{days} days"))
-                                    } else {
-                                        None
-                                    }
-                                }
-                                Err(_) => {
-                                    let rel_path = to_forward_slash(path);
-                                    eprintln!(
-                                        "Warning: invalid last_verified in {rel_path}: \"{date_str}\""
-                                    );
-                                    Some("invalid last_verified".to_string())
-                                }
+                        let reason = fm.last_verified.as_ref().map_or_else(
+                            || Some("no last_verified".to_string()),
+                            |date_str| {
+                                NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_or_else(
+                                    |_| {
+                                        let rel_path = to_forward_slash(path);
+                                        eprintln!(
+                                            "Warning: invalid last_verified in {rel_path}: \"{date_str}\""
+                                        );
+                                        Some("invalid last_verified".to_string())
+                                    },
+                                    |date| {
+                                        let days = (today - date).num_days();
+                                        if days > i64::from(threshold) {
+                                            Some(format!("{days} days"))
+                                        } else {
+                                            None
+                                        }
+                                    },
+                                )
                             },
-                        };
+                        );
                         if let Some(reason) = reason {
                             stale_entries.push(StaleEntry {
                                 name: fm.name,

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -54,6 +54,9 @@ fn comment_syntax(ext: &str) -> Option<(&'static str, &'static str)> {
     }
 }
 
+/// # Errors
+///
+/// Returns [`SpecreError`] on invalid arguments, I/O, or serialization failure.
 pub fn execute(args: TagArgs, json: bool) -> Result<(), SpecreError> {
     if !ulid::is_valid(&args.ulid) {
         return Err(SpecreError::InvalidArgument(
@@ -90,8 +93,7 @@ pub fn execute(args: TagArgs, json: bool) -> Result<(), SpecreError> {
             let line = content
                 .lines()
                 .position(|l| l.contains(&marker_pattern))
-                .map(|n| n + 1)
-                .unwrap_or(1);
+                .map_or(1, |n| n + 1);
             let output = TagOutput {
                 id: args.ulid,
                 file: to_forward_slash(file_path).into_owned(),
@@ -109,8 +111,7 @@ pub fn execute(args: TagArgs, json: bool) -> Result<(), SpecreError> {
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
     let (prefix, suffix) = comment_syntax(ext).ok_or_else(|| {
         SpecreError::InvalidArgument(format!(
-            "unsupported file extension '.{}' — comment syntax is unknown",
-            ext
+            "unsupported file extension '.{ext}' — comment syntax is unknown"
         ))
     })?;
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -37,7 +37,11 @@ struct SpecreRefOutput {
     path: Option<String>,
 }
 
-pub fn execute(args: TraceArgs, json: bool) -> Result<(), SpecreError> {
+/// # Errors
+///
+/// Returns [`SpecreError`] on config, I/O, or serialization failure, or
+/// [`SpecreError::NonZeroExit`] when no trace results are found.
+pub fn execute(args: &TraceArgs, json: bool) -> Result<(), SpecreError> {
     if ulid::is_valid(&args.query) {
         trace_by_ulid(&args.query, json)
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,12 @@ pub struct SearchConfig {
     pub max_results: Option<usize>,
 }
 
+/// Loads and parses `specre.toml` from the current directory.
+///
+/// # Errors
+///
+/// Returns [`SpecreError::ConfigNotFound`] if `specre.toml` is missing,
+/// or [`SpecreError::ConfigParse`] if deserialization fails.
 pub fn load() -> Result<Config, SpecreError> {
     let path = Path::new(CONFIG_FILE);
     if !path.exists() {
@@ -47,6 +53,7 @@ pub fn load() -> Result<Config, SpecreError> {
     toml::from_str(&content).map_err(SpecreError::ConfigParse)
 }
 
+#[must_use]
 pub fn load_language() -> String {
     load()
         .ok()

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,15 @@ fn main() {
 
     let result = match cli.command {
         Commands::Init(args) => commands::init::execute(args, json),
-        Commands::New(args) => commands::new::execute(args, json),
+        Commands::New(ref args) => commands::new::execute(args, json),
         Commands::Index => commands::index::execute(json),
-        Commands::Status(args) => commands::status::execute(args, json),
-        Commands::Trace(args) => commands::trace::execute(args, json),
+        Commands::Status(ref args) => commands::status::execute(args, json),
+        Commands::Trace(ref args) => commands::trace::execute(args, json),
         Commands::Orphans => commands::orphans::execute(json),
         Commands::Tag(args) => commands::tag::execute(args, json),
         Commands::Coverage(args) => commands::coverage::execute(args, json),
         Commands::HealthCheck => commands::health_check::execute(),
-        Commands::Search(args) => commands::search::execute(args),
+        Commands::Search(ref args) => commands::search::execute(args),
         Commands::Mcp => commands::mcp::execute(),
     };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,6 +41,19 @@ impl std::error::Error for FrontmatterError {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RawFrontmatter {
+    id: String,
+    name: String,
+    status: Status,
+    last_verified: Option<String>,
+}
+
+/// Parses YAML front-matter delimited by `---` from specre card content.
+///
+/// # Errors
+///
+/// Returns [`FrontmatterError`] if delimiters are missing or the YAML is invalid.
 pub fn parse_frontmatter(content: &str) -> Result<Frontmatter, FrontmatterError> {
     let content = content.trim_start_matches('\u{feff}'); // BOM
     if !content.starts_with("---") {
@@ -51,14 +64,6 @@ pub fn parse_frontmatter(content: &str) -> Result<Frontmatter, FrontmatterError>
         .find("\n---")
         .ok_or(FrontmatterError::NoClosingDelimiter)?;
     let block = &after_first[..end];
-
-    #[derive(serde::Deserialize)]
-    struct RawFrontmatter {
-        id: String,
-        name: String,
-        status: Status,
-        last_verified: Option<String>,
-    }
 
     let raw: RawFrontmatter = serde_yaml::from_str(block).map_err(FrontmatterError::Yaml)?;
 
@@ -73,6 +78,7 @@ pub fn parse_frontmatter(content: &str) -> Result<Frontmatter, FrontmatterError>
 /// Extracts a ULID from a `@specre` marker on a line.
 /// Returns None if the marker appears inside a string literal
 /// (preceded by a quote character `"` or `'` on the same line).
+#[must_use]
 pub fn extract_marker_ulid(line: &str) -> Option<&str> {
     let pos = line.find("@specre ")?;
     let before = &line[..pos];

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -27,14 +27,13 @@ pub fn collect_md_files<F: FnMut(&Path)>(dir: &Path, cb: &mut F) {
             }
         })
         .collect();
-    sub_entries.sort_by_key(|e| e.file_name());
+    sub_entries.sort_by_key(std::fs::DirEntry::file_name);
     for entry in sub_entries {
         let path = entry.path();
         if path.is_dir() {
             if path
                 .file_name()
-                .map(|n| n.to_string_lossy().starts_with('.'))
-                .unwrap_or(false)
+                .is_some_and(|n| n.to_string_lossy().starts_with('.'))
             {
                 continue;
             }
@@ -73,27 +72,26 @@ pub fn collect_all_files<F: FnMut(&Path)>(
             }
         })
         .collect();
-    sub_entries.sort_by_key(|e| e.file_name());
+    sub_entries.sort_by_key(std::fs::DirEntry::file_name);
     for entry in sub_entries {
         let path = entry.path();
         if path.is_dir() {
             if path
                 .file_name()
-                .map(|n| n.to_string_lossy().starts_with('.'))
-                .unwrap_or(false)
+                .is_some_and(|n| n.to_string_lossy().starts_with('.'))
             {
                 continue;
             }
             collect_all_files(&path, target_extensions, cb);
-        } else {
-            if let Some(exts) = target_extensions {
-                let matches = path
-                    .extension()
-                    .is_some_and(|ext| exts.iter().any(|e| e == ext.to_string_lossy().as_ref()));
-                if !matches {
-                    continue;
-                }
+        } else if let Some(exts) = target_extensions {
+            let matches = path
+                .extension()
+                .is_some_and(|ext| exts.iter().any(|e| e == ext.to_string_lossy().as_ref()));
+            if !matches {
+                continue;
             }
+            cb(&path);
+        } else {
             cb(&path);
         }
     }
@@ -122,6 +120,7 @@ pub struct MarkerLocation {
 }
 
 /// Scans all files in `source_dirs` once, collecting both coverage and marker data.
+#[must_use]
 pub fn scan_source_markers(
     source_dirs: &[String],
     target_extensions: Option<&[String]>,

--- a/src/status.rs
+++ b/src/status.rs
@@ -18,10 +18,10 @@ pub enum Status {
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Status::Draft => write!(f, "draft"),
-            Status::InDevelopment => write!(f, "in-development"),
-            Status::Stable => write!(f, "stable"),
-            Status::Deprecated => write!(f, "deprecated"),
+            Self::Draft => write!(f, "draft"),
+            Self::InDevelopment => write!(f, "in-development"),
+            Self::Stable => write!(f, "stable"),
+            Self::Deprecated => write!(f, "deprecated"),
         }
     }
 }
@@ -31,10 +31,10 @@ impl FromStr for Status {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "draft" => Ok(Status::Draft),
-            "in-development" => Ok(Status::InDevelopment),
-            "stable" => Ok(Status::Stable),
-            "deprecated" => Ok(Status::Deprecated),
+            "draft" => Ok(Self::Draft),
+            "in-development" => Ok(Self::InDevelopment),
+            "stable" => Ok(Self::Stable),
+            "deprecated" => Ok(Self::Deprecated),
             other => Err(format!(
                 "invalid status: {other}. Expected one of: draft, in-development, stable, deprecated."
             )),

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,5 +1,6 @@
 // @specre 01JMBJK7QRVX3N4P5G6H8W9Y0Z
 // @specre 01KHDF9WHR5HFM4RQCF6HS3KCC
+#[must_use]
 pub fn render(id: &str, name: &str, language: &str) -> String {
     let (related, overview, scenarios) = section_headings(language);
     format!(

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -1,12 +1,14 @@
 // @specre 01JMBJK7QRVX3N4P5G6H8W9Y0Z
 use ulid::Ulid;
 
+#[must_use]
 pub fn is_valid(s: &str) -> bool {
     s.len() == 26
         && s.chars()
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
 }
 
+#[must_use]
 pub fn generate() -> String {
     Ulid::new().to_string()
 }


### PR DESCRIPTION
## Summary
- Add `[lints.clippy]` section to `Cargo.toml` with `pedantic`, `nursery`, and `all` groups set to `deny`
- Fix all 50+ clippy violations across 21 source files (0 remaining warnings)
- All 258 tests continue to pass

## Changes
- **Cargo.toml**: Add lint configuration with two justified global allows (`module_name_repetitions`, `cast_precision_loss`)
- **All source files**: Apply idiomatic Rust patterns — `#[must_use]`, `Self::` in impls, `map_or`/`map_or_else`/`is_some_and`, `const fn`, explicit imports, `# Errors` docs, pass-by-reference for clap args, `writeln!` over `push_str(&format!())`, etc.

## Test plan
- [x] `cargo clippy` passes with 0 warnings
- [x] `cargo test` passes all 258 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)