### PR TITLE
docs: add Rust conventions guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -349,6 +349,8 @@ class QuotationService:
 
 specre は初期段階にあります。コントリビューション、フィードバック、実際の使用レポートを歓迎します。GitHub で Issue または Pull Request を開いてください。
 
+Rust コードをコントリビュートする場合は、Pull Request を提出する前に **[Rust Conventions](docs/guides/RUST-CONVENTIONS.md)** をお読みください。
+
 ## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Each entry records a `@specre` marker found in the source tree:
 
 specre is in its early stages. Contributions, feedback, and real-world usage reports are welcome. Please open an issue or pull request on GitHub.
 
+If you are contributing Rust code, please read the **[Rust Conventions](docs/guides/RUST-CONVENTIONS.md)** before submitting a pull request.
+
 ## License
 
 MIT

--- a/docs/guides/RUST-CONVENTIONS.md
+++ b/docs/guides/RUST-CONVENTIONS.md
@@ -1,0 +1,31 @@
+# Rust Conventions
+
+## Types
+- All public structs and enums MUST derive `Debug`
+- Filesystem paths MUST use `PathBuf` (owned) or `&Path` (borrowed), never `String`
+- CLI args that have a corresponding type (Status, NaiveDate, PathBuf) MUST
+  parse at the clap boundary, not in the command handler
+- Prefer `Cow<'_, str>` over `String` when the value may or may not need allocation
+
+## Error Handling
+- Never use `unwrap()`, `expect()`, or `Box<dyn Error>` in non-test code
+- All `From` conversions for `SpecreError` variants MUST be implemented
+  when the same `.map_err(SpecreError::Variant)` appears more than twice
+- File I/O: attempt the operation first, match on ErrorKind.
+  Never check `path.exists()` before `fs::read/write` (TOCTOU)
+
+## Performance
+- Never allocate inside a per-item closure when the value is loop-invariant
+  (e.g., `to_lowercase()` on a query string)
+- Use `Rc<str>` (not Arc, not String::clone) for shared strings in
+  single-threaded hot paths
+
+## Dependencies
+- Never add a dependency whose repository is archived or unmaintained
+- Prefer crates with >1M downloads or maintained by known teams
+- Always use `default-features = false` and enable only needed features
+
+## Code Organization
+- No logic duplication across modules. If two functions share >10 lines
+  of structural logic, extract a shared helper
+- Comments in source code MUST be in English


### PR DESCRIPTION
## Summary
- Add `docs/guides/RUST-CONVENTIONS.md` covering types, error handling, performance, dependencies, and code organization rules
- Link the guide from the Contributing section in both `README.md` and `README.ja.md`

## Test plan
- [x] Verify the markdown renders correctly on GitHub
- [x] Verify links from both READMEs resolve to the new guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)