### PR TITLE
chore: derive Debug on all public types

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 /// This is the single source of truth for specre card data,
 /// replacing per-command struct definitions (`SpecreEntry`,
 /// `CardData`, `ScannedCard`) with one shared type.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SpecreCard {
     pub id: String,
     pub name: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 // @specre 01KHFFCX8BCDAYP8YHG0J65H0E
 use clap::{Args, Parser, Subcommand};
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(
     name = "specre",
     version,
@@ -16,7 +16,7 @@ pub struct Cli {
     pub command: Commands,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 pub enum Commands {
     /// Initialize specre in a project
     Init(InitArgs),
@@ -52,7 +52,7 @@ pub enum Commands {
     Mcp,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct SearchArgs {
     /// Free-text substring to match against card content (case-insensitive)
     pub query: Option<String>,
@@ -78,7 +78,7 @@ pub struct SearchArgs {
     pub limit: Option<usize>,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct InitArgs {
     /// Directory where specre cards are stored
     #[arg(long, default_value = "docs/specres")]
@@ -97,20 +97,20 @@ pub struct InitArgs {
     pub ext: Option<Vec<String>>,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct StatusArgs {
     /// Number of days after which a stable specre's `last_verified` is considered stale
     #[arg(long, default_value_t = 30)]
     pub threshold: u32,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct TraceArgs {
     /// ULID (26 uppercase alphanumeric characters) or file path to look up
     pub query: String,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct TagArgs {
     /// ULID to insert as a marker (26 uppercase alphanumeric characters)
     pub ulid: String,
@@ -119,14 +119,14 @@ pub struct TagArgs {
     pub file: String,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct CoverageArgs {
     /// Target file extensions to filter by (comma-separated, e.g., "rs,ts")
     #[arg(long, value_delimiter = ',')]
     pub ext: Option<Vec<String>>,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 pub struct NewArgs {
     /// Target directory where the specre file will be created
     pub target_dir: String,

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -14,6 +14,7 @@ struct CoverageOutput {
     uncovered: Vec<String>,
 }
 
+#[derive(Debug)]
 pub struct CoverageResult {
     pub total: usize,
     pub tagged: usize,

--- a/src/commands/orphans.rs
+++ b/src/commands/orphans.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use std::collections::HashSet;
 use std::path::Path;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct DanglingMarkerDetail {
     pub file: String,
     pub line: usize,
@@ -17,7 +17,7 @@ pub struct DanglingMarkerDetail {
     pub ulid: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct OrphanResult {
     pub orphan_specres: Vec<String>,
     pub dangling_markers: Vec<DanglingMarkerDetail>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 const CONFIG_FILE: &str = "specre.toml";
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Config {
     pub specre_dir: String,
     pub source_dirs: Vec<String>,
@@ -23,14 +23,14 @@ pub struct Config {
     pub search: Option<SearchConfig>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct HealthCheckConfig {
     pub coverage: Option<f64>,
     pub orphans: Option<usize>,
     pub index_age_hours: Option<f64>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct SearchConfig {
     pub max_results: Option<usize>,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,7 @@
 use crate::status::Status;
 use std::fmt;
 
+#[derive(Debug)]
 pub struct Frontmatter {
     pub id: String,
     pub name: String,

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -100,6 +100,7 @@ pub fn collect_all_files<F: FnMut(&Path)>(
 /// Result of a single-pass scan of all source files for `@specre` markers.
 /// Used by `compute_coverage`, `compute_orphans`, and `health_check` to
 /// avoid duplicate directory traversals and file reads.
+#[derive(Debug)]
 pub struct SourceScanResult {
     /// Total number of source files scanned.
     pub total: usize,
@@ -113,6 +114,7 @@ pub struct SourceScanResult {
     pub all_markers: Vec<MarkerLocation>,
 }
 
+#[derive(Debug)]
 pub struct MarkerLocation {
     pub file: String,
     pub line: usize,


### PR DESCRIPTION
## Summary
- Add `#[derive(Debug)]` to all 19 public types that were missing it, per [Rust API Guidelines C-DEBUG](https://rust-lang.github.io/api-guidelines/debuggability.html#c-debug)
- Affected files: `cli.rs`, `card.rs`, `config.rs`, `parser.rs`, `scanner.rs`, `commands/orphans.rs`, `commands/coverage.rs`
- All existing tests (245) and strict Clippy lints pass

Closes #79

## Test plan
- [x] `cargo clippy` passes with strict lints
- [x] `cargo test` — all 245 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)