### PR TITLE
Add MCP health-check preflight to CLAUDE.md and workflow commands

### DIFF
--- a/.claude/commands/refine-glossary.md
+++ b/.claude/commands/refine-glossary.md
@@ -4,6 +4,13 @@ The glossary directly controls the quality of `suggested_terms` in search hints.
 
 ---
 
+## Phase 0: MCP Preflight
+
+If specre MCP tools are available, run `health-check` first.
+
+- **healthy = true** → The specre ecosystem is trustworthy. Proceed — `specre search` results in Phase 2 will accurately reflect the card corpus.
+- **healthy = false** → The index or coverage may be stale. Run `specre index` to regenerate, then re-run `health-check`. If still unhealthy, note the gaps but proceed with caution — audit results may be incomplete.
+
 ## Phase 1: Context
 
 1. Read `README.md` — internalize the philosophy, especially "context-window aware" and "one file, one behavior"

--- a/.claude/commands/sdd-code-quality.md
+++ b/.claude/commands/sdd-code-quality.md
@@ -4,7 +4,16 @@ Follow these phases strictly. This workflow iterates over each affected file, up
 
 ---
 
-## Phase 0: Branch Setup
+## Phase 0: Preflight
+
+### 0.1 MCP Preflight
+
+If specre MCP tools are available, run `health-check` first.
+
+- **healthy = true** → The specre ecosystem is trustworthy. Use `specre search` / `specre trace` for all exploration in subsequent phases.
+- **healthy = false** → Fall back to `grep` / `glob` for code exploration instead of relying on specre tools. Specre cards can still be read as reference, but do not trust coverage or traceability to be complete.
+
+### 0.2 Branch Setup
 
 1. Check the current branch with `git branch --show-current`
 2. If on `main`, create and checkout an appropriate branch (e.g., `chore/code-quality-<short-description>`)

--- a/.claude/commands/sdd-fix.md
+++ b/.claude/commands/sdd-fix.md
@@ -4,6 +4,13 @@ Follow these phases strictly. There is exactly ONE human checkpoint — after th
 
 ---
 
+## Phase 0: MCP Preflight
+
+If specre MCP tools are available, run `health-check` first.
+
+- **healthy = true** → The specre ecosystem is trustworthy. Proceed to Phase 1 and use `specre search` / `specre trace` for all exploration.
+- **healthy = false** → Fall back to `grep` / `glob` for code exploration instead of relying on specre tools. Specre cards can still be read as reference, but do not trust coverage or traceability to be complete.
+
 ## Phase 1: Analysis
 
 1. Read `README.md` and `docs/project/ROADMAP.md` to understand the project philosophy and roadmap context

--- a/.claude/commands/sdd-new.md
+++ b/.claude/commands/sdd-new.md
@@ -4,6 +4,13 @@ Follow these phases strictly. There is exactly ONE human checkpoint — after th
 
 ---
 
+## Phase 0: MCP Preflight
+
+If specre MCP tools are available, run `health-check` first.
+
+- **healthy = true** → The specre ecosystem is trustworthy. Proceed to Phase 1 and use `specre search` / `specre trace` for all exploration.
+- **healthy = false** → Fall back to `grep` / `glob` for code exploration instead of relying on specre tools. Specre cards can still be read as reference, but do not trust coverage or traceability to be complete.
+
 ## Phase 1: Analysis
 
 1. Read `README.md` and `docs/project/ROADMAP.md` to understand the project philosophy and where the feature fits in the roadmap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,36 @@ specre/
 3. Update tests, then implementation.
 4. Update `last_verified` to today's date.
 
+## MCP Preflight: Health-Check First
+
+When specre MCP tools are available in the agent's tool list, **always run `health-check` before any other specre operation.** This single call determines the exploration strategy for the entire session.
+
+### healthy = true
+
+The specre ecosystem — specification cards, traceability links, index, and coverage — is in a trustworthy state. Leverage it aggressively:
+
+- **Use `specre search`** to locate relevant specre cards. The most effective pattern is an AND query combining a **noun** (the subject) and an **operation** (what it does):
+  - `specre search "trace bidirectional"` — finds the traceability specre card
+  - `specre search "orphan detect"` — finds the orphan detection specre card
+  - `specre search "mcp server"` — finds MCP-related specre cards
+  - Add `--or` only when the AND query is too narrow
+- **Use `specre trace`** to navigate between specre cards, source files, and test files:
+  - `specre trace <ULID>` — from specre card to all linked source/test files
+  - `specre trace <file-path>` — from source file to governing specre card(s)
+- **Trust the specre cards** as the authoritative description of each behavior. Read the card's Scenarios and Related Files before modifying code.
+
+### healthy = false
+
+The specre ecosystem has gaps (low coverage, orphans, or stale index). Do **not** rely on specre tools for navigation — results may be incomplete or misleading. Instead:
+
+- Fall back to `grep` / `glob` for code exploration
+- Read source files and tests directly
+- Treat specre cards as reference material, not as the single source of truth
+
+### Why this matters
+
+A healthy specre ecosystem means every behavior has a specification, every source file is traced, and the index is current. An agent that trusts this ecosystem can find the right files in 1-2 tool calls instead of broad codebase searches. When the ecosystem is unhealthy, that trust is misplaced — and grep is more reliable.
+
 ## specre Card Format
 
 Every specre card follows this structure:


### PR DESCRIPTION
Establish a standard pattern: when specre MCP tools are available, always run health-check first to determine the exploration strategy. healthy=true means the specre ecosystem is trustworthy (use search/trace), healthy=false means fall back to grep/glob.

Updated files:
- CLAUDE.md: new "MCP Preflight: Health-Check First" section
- sdd-new.md: Phase 0 MCP Preflight
- sdd-fix.md: Phase 0 MCP Preflight
- sdd-code-quality.md: Phase 0.1 MCP Preflight (before Branch Setup)
- refine-glossary.md: Phase 0 MCP Preflight

https://claude.ai/code/session_01B7pootQNkTniTPX4Po6VuZ