### PR TITLE
fix: resolve clippy errors for Unix target compilation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn tokio_runtime_display() {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "cannot create runtime");
+        let inner = std::io::Error::other("cannot create runtime");
         let err = SpecreError::TokioRuntime(inner);
         assert_eq!(
             err.to_string(),
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn io_source_returns_some() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "oops");
+        let io_err = std::io::Error::other("oops");
         let err = SpecreError::Io {
             path: PathBuf::from("x"),
             source: io_err,
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn tokio_runtime_source_returns_some() {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "err");
+        let inner = std::io::Error::other("err");
         let err = SpecreError::TokioRuntime(inner);
         assert!(err.source().is_some());
     }

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -332,7 +332,7 @@ fn coverage_warns_on_unreadable_source_file() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = TempDir::new().unwrap();
-    write_config(tmp.path(), "docs/specres", &["src"], &["rs"]);
+    write_config(tmp.path(), "docs/specres", &["src"]);
 
     let src_dir = tmp.path().join("src");
     fs::create_dir_all(&src_dir).unwrap();

--- a/tests/cli_health_check.rs
+++ b/tests/cli_health_check.rs
@@ -509,9 +509,8 @@ fn health_check_warns_on_unreadable_index_json() {
     );
 
     // Create index.json but make it unreadable
+    write_index_json(tmp.path(), &recent_timestamp());
     let index_path = tmp.path().join("docs/specres/index.json");
-    let generated_at = fresh_index_timestamp(0);
-    fs::write(&index_path, make_index_json(&generated_at)).unwrap();
     fs::set_permissions(&index_path, fs::Permissions::from_mode(0o000)).unwrap();
 
     let output = specre()

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -2,13 +2,14 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
+use std::fmt::Write;
 use std::fs;
 
 fn specre() -> assert_cmd::Command {
     cargo_bin_cmd!("specre")
 }
 
-/// Helper: create specre.toml with given specre_dir and source_dirs
+/// Helper: create `specre.toml` with given `specre_dir` and `source_dirs`
 fn write_config(dir: &std::path::Path, specre_dir: &str, source_dirs: &[&str]) {
     let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
     let content = format!(
@@ -18,7 +19,7 @@ fn write_config(dir: &std::path::Path, specre_dir: &str, source_dirs: &[&str]) {
     fs::write(dir.join("specre.toml"), content).unwrap();
 }
 
-/// Helper: create specre.toml with target_extensions
+/// Helper: create `specre.toml` with `target_extensions`
 fn write_config_with_ext(
     dir: &std::path::Path,
     specre_dir: &str,
@@ -48,7 +49,7 @@ fn write_specre(
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     let mut fm = format!("---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n");
     if let Some(lv) = last_verified {
-        fm.push_str(&format!("last_verified: \"{lv}\"\n"));
+        let _ = writeln!(fm, "last_verified: \"{lv}\"");
     }
     fm.push_str("---\n\n## Related Files\n\n-\n");
     fs::write(path, fm).unwrap();
@@ -517,7 +518,7 @@ fn index_ignores_markers_inside_string_literals() {
         &[
             "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA",
             r#"    write_source(tmp.path(), "src/a.rs", "// @specre 01BBBBBBBBBBBBBBBBBBBBBBBB\n");"#,
-            r#"    let s = '// @specre 01CCCCCCCCCCCCCCCCCCCCCCCC';"#,
+            r"    let s = '// @specre 01CCCCCCCCCCCCCCCCCCCCCCCC';",
             "",
         ]
         .join("\n"),

--- a/tests/cli_json_output.rs
+++ b/tests/cli_json_output.rs
@@ -3,13 +3,14 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
 use serde_json::Value;
+use std::fmt::Write;
 use std::fs;
 
 fn specre() -> assert_cmd::Command {
     cargo_bin_cmd!("specre")
 }
 
-/// Helper: create specre.toml with given specre_dir and source_dirs
+/// Helper: create `specre.toml` with given `specre_dir` and `source_dirs`
 fn write_config(dir: &std::path::Path, specre_dir: &str) {
     let content = format!("specre_dir = \"{specre_dir}\"\nsource_dirs = [\"src\"]\n");
     fs::write(dir.join("specre.toml"), content).unwrap();
@@ -28,7 +29,7 @@ fn write_specre(
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     let mut fm = format!("---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n");
     if let Some(lv) = last_verified {
-        fm.push_str(&format!("last_verified: \"{lv}\"\n"));
+        let _ = writeln!(fm, "last_verified: \"{lv}\"");
     }
     fm.push_str("---\n\n## Related Files\n\n-\n");
     fs::write(path, fm).unwrap();

--- a/tests/cli_search.rs
+++ b/tests/cli_search.rs
@@ -49,10 +49,7 @@ fn write_specre_card_full(
 ) {
     let path = dir.join(rel_path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
-    let lv = match last_verified {
-        Some(d) => format!("last_verified: \"{d}\"\n"),
-        None => String::new(),
-    };
+    let lv = last_verified.map_or_else(String::new, |d| format!("last_verified: \"{d}\"\n"));
     let content = format!(
         "---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n{lv}---\n\n{body}"
     );
@@ -489,7 +486,7 @@ fn search_truncated_when_exceeds_threshold() {
     assert_eq!(json["truncated"], true);
     assert!(json["results"].as_array().unwrap().is_empty());
     // hint should be present
-    assert!(json["hint"]["message"].as_str().unwrap().contains("5"));
+    assert!(json["hint"]["message"].as_str().unwrap().contains('5'));
     let domains = json["hint"]["available_domains"].as_array().unwrap();
     let domain_strs: Vec<&str> = domains.iter().map(|d| d.as_str().unwrap()).collect();
     assert!(domain_strs.contains(&"auth"));
@@ -1385,7 +1382,7 @@ fn search_no_results_single_keyword_with_glossary_shows_hint() {
     // Hint should be present (glossary exists)
     let hint = &json["hint"];
     assert!(hint["message"].as_str().is_some());
-    assert!(hint["suggested_terms"].as_array().unwrap().len() > 0);
+    assert!(!hint["suggested_terms"].as_array().unwrap().is_empty());
 }
 
 // -- Scenario: Results exceed truncation threshold with glossary --
@@ -1494,7 +1491,7 @@ fn search_truncated_without_glossary_no_suggested_terms() {
         write_specre_card(
             &tmp,
             &format!("docs/specres/cli/card_{i}.md"),
-            &format!("01{:A<24}", i),
+            &format!("01{i:A<24}"),
             &format!("card_{i}"),
             "stable",
         );

--- a/tests/cli_status.rs
+++ b/tests/cli_status.rs
@@ -3,13 +3,14 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use chrono::{Days, Utc};
 use predicates::prelude::*;
+use std::fmt::Write;
 use std::fs;
 
 fn specre() -> assert_cmd::Command {
     cargo_bin_cmd!("specre")
 }
 
-/// Helper: create specre.toml with given specre_dir
+/// Helper: create `specre.toml` with given `specre_dir`
 fn write_config(dir: &std::path::Path, specre_dir: &str) {
     let content = format!("specre_dir = \"{specre_dir}\"\nsource_dirs = [\"src\"]\n");
     fs::write(dir.join("specre.toml"), content).unwrap();
@@ -28,7 +29,7 @@ fn write_specre(
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     let mut fm = format!("---\nid: \"{id}\"\nname: \"{name}\"\nstatus: \"{status}\"\n");
     if let Some(lv) = last_verified {
-        fm.push_str(&format!("last_verified: \"{lv}\"\n"));
+        let _ = writeln!(fm, "last_verified: \"{lv}\"");
     }
     fm.push_str("---\n\n## Related Files\n\n-\n");
     fs::write(path, fm).unwrap();

--- a/tests/cli_tag.rs
+++ b/tests/cli_tag.rs
@@ -686,7 +686,16 @@ fn tag_shows_path_in_io_error() {
         );
 
     // Restore permissions for cleanup
-    let mut perms = fs::metadata(path).unwrap().permissions();
-    perms.set_readonly(false);
-    fs::set_permissions(path, perms).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+    #[cfg(not(unix))]
+    {
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        fs::set_permissions(path, perms).unwrap();
+    }
 }

--- a/tests/mcp/tool_health_check.rs
+++ b/tests/mcp/tool_health_check.rs
@@ -19,7 +19,7 @@ fn call_health_check(stdin: &mut impl std::io::Write, reader: &mut BufReader<imp
     recv(reader)
 }
 
-/// Helper: create a fresh index.json with a recent generated_at timestamp.
+/// Helper: create a fresh index.json with a recent `generated_at` timestamp.
 fn create_fresh_index(dir: &assert_fs::TempDir, specre_dir: &str) {
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let index = serde_json::json!({

--- a/tests/mcp/tool_index.rs
+++ b/tests/mcp/tool_index.rs
@@ -47,7 +47,7 @@ fn mcp_tool_index_with_cards() {
     assert_eq!(payload["index_file"], "docs/specres/index.json");
     assert_eq!(payload["specre_count"], 2);
     assert_eq!(payload["source_ref_count"], 1);
-    assert!(payload["index_md_files"].as_array().unwrap().len() >= 1);
+    assert!(!payload["index_md_files"].as_array().unwrap().is_empty());
 
     // Verify index.json was actually created
     let index_path = dir.path().join("docs/specres/index.json");

--- a/tests/mcp/tool_new.rs
+++ b/tests/mcp/tool_new.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::io::BufReader;
 
 /// Helper: call the `new` tool and return the response.
-fn call_new(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: Value) -> Value {
+fn call_new(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: &Value) -> Value {
     send(stdin, &json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -31,7 +31,7 @@ fn mcp_tool_new_creates_card_with_name() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_new(&mut stdin, &mut reader, 2, json!({
+    let response = call_new(&mut stdin, &mut reader, 2, &json!({
         "target_dir": "docs/specres/auth",
         "name": "user_can_sign_up"
     }));
@@ -71,7 +71,7 @@ fn mcp_tool_new_defaults_to_untitled() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_new(&mut stdin, &mut reader, 2, json!({
+    let response = call_new(&mut stdin, &mut reader, 2, &json!({
         "target_dir": "docs/specres/misc"
     }));
 
@@ -102,7 +102,7 @@ fn mcp_tool_new_creates_directory_recursively() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_new(&mut stdin, &mut reader, 2, json!({
+    let response = call_new(&mut stdin, &mut reader, 2, &json!({
         "target_dir": "docs/specres/new_domain/sub",
         "name": "some_behavior"
     }));
@@ -131,7 +131,7 @@ fn mcp_tool_new_errors_when_file_exists() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_new(&mut stdin, &mut reader, 2, json!({
+    let response = call_new(&mut stdin, &mut reader, 2, &json!({
         "target_dir": "docs/specres/domain",
         "name": "existing"
     }));
@@ -159,7 +159,7 @@ fn mcp_tool_new_errors_when_target_is_file() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_new(&mut stdin, &mut reader, 2, json!({
+    let response = call_new(&mut stdin, &mut reader, 2, &json!({
         "target_dir": "docs/specres/not_a_dir",
         "name": "some_behavior"
     }));

--- a/tests/mcp/tool_search.rs
+++ b/tests/mcp/tool_search.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::io::BufReader;
 
 /// Helper: call the `search` tool and return the response.
-fn call_search(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: Value) -> Value {
+fn call_search(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: &Value) -> Value {
     send(stdin, &json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -34,7 +34,7 @@ fn mcp_tool_search_by_keyword() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "query": "card_a"
     }));
 
@@ -67,7 +67,7 @@ fn mcp_tool_search_by_status() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "status": "draft"
     }));
 
@@ -95,7 +95,7 @@ fn mcp_tool_search_by_domain() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "domain": "auth"
     }));
 
@@ -121,7 +121,7 @@ fn mcp_tool_search_no_results() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "query": "nonexistent_keyword"
     }));
 
@@ -149,7 +149,7 @@ fn mcp_tool_search_with_limit() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "limit": 1
     }));
 
@@ -185,7 +185,7 @@ fn mcp_tool_search_truncation_with_hint() {
     initialize(&mut stdin, &mut reader);
 
     // Search with no limit — 3 results exceed max_results=2
-    let response = call_search(&mut stdin, &mut reader, 2, json!({}));
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({}));
 
     let payload: Value = serde_json::from_str(response["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
     assert_eq!(payload["total"], 3);
@@ -223,7 +223,7 @@ fn mcp_tool_search_limit_bypasses_truncation() {
     initialize(&mut stdin, &mut reader);
 
     // Explicit limit bypasses truncation — returns results even though total > max_results
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "limit": 2
     }));
 
@@ -250,7 +250,7 @@ fn mcp_tool_search_invalid_status() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_search(&mut stdin, &mut reader, 2, json!({
+    let response = call_search(&mut stdin, &mut reader, 2, &json!({
         "status": "invalid_status"
     }));
 

--- a/tests/mcp/tool_status.rs
+++ b/tests/mcp/tool_status.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::io::BufReader;
 
 /// Helper: call the `status` tool and return the response.
-fn call_status(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: Value) -> Value {
+fn call_status(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: &Value) -> Value {
     send(stdin, &json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -35,7 +35,7 @@ fn mcp_tool_status_mixed() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_status(&mut stdin, &mut reader, 2, json!({}));
+    let response = call_status(&mut stdin, &mut reader, 2, &json!({}));
 
     assert_eq!(response["id"], 2);
     let result = &response["result"];
@@ -74,7 +74,7 @@ fn mcp_tool_status_custom_threshold() {
     initialize(&mut stdin, &mut reader);
 
     // With default threshold (30 days), card is not stale
-    let response = call_status(&mut stdin, &mut reader, 2, json!({}));
+    let response = call_status(&mut stdin, &mut reader, 2, &json!({}));
     let payload: Value = serde_json::from_str(response["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
     assert!(payload["stale"].as_array().unwrap().is_empty(), "should not be stale with default threshold");
 
@@ -95,7 +95,7 @@ fn mcp_tool_status_empty() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_status(&mut stdin, &mut reader, 2, json!({}));
+    let response = call_status(&mut stdin, &mut reader, 2, &json!({}));
 
     let payload: Value = serde_json::from_str(response["result"]["content"][0]["text"].as_str().unwrap()).unwrap();
     assert_eq!(payload["summary"]["total"], 0);

--- a/tests/mcp/tool_tag.rs
+++ b/tests/mcp/tool_tag.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::io::BufReader;
 
 /// Helper: call the `tag` tool and return the response.
-fn call_tag(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: Value) -> Value {
+fn call_tag(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: &Value) -> Value {
     send(stdin, &json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -34,7 +34,7 @@ fn mcp_tool_tag_inserts_marker() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "01HZYPMZRK8F9R2DGBGGMM2N8T",
         "file": "src/example.rs"
     }));
@@ -78,7 +78,7 @@ fn mcp_tool_tag_returns_existing_marker() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "01HZYPMZRK8F9R2DGBGGMM2N8T",
         "file": "src/example.rs"
     }));
@@ -113,7 +113,7 @@ fn mcp_tool_tag_errors_on_invalid_ulid() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "abc123",
         "file": "src/example.rs"
     }));
@@ -144,7 +144,7 @@ fn mcp_tool_tag_errors_on_missing_file() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "01HZYPMZRK8F9R2DGBGGMM2N8T",
         "file": "src/nonexistent.rs"
     }));
@@ -172,7 +172,7 @@ fn mcp_tool_tag_errors_on_directory() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "01HZYPMZRK8F9R2DGBGGMM2N8T",
         "file": "src"
     }));
@@ -201,7 +201,7 @@ fn mcp_tool_tag_errors_on_unsupported_extension() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_tag(&mut stdin, &mut reader, 2, json!({
+    let response = call_tag(&mut stdin, &mut reader, 2, &json!({
         "ulid": "01HZYPMZRK8F9R2DGBGGMM2N8T",
         "file": "data/config.xyz"
     }));

--- a/tests/mcp/tool_trace.rs
+++ b/tests/mcp/tool_trace.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::io::BufReader;
 
 /// Helper: call the `trace` tool and return the response.
-fn call_trace(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: Value) -> Value {
+fn call_trace(stdin: &mut impl std::io::Write, reader: &mut BufReader<impl std::io::Read>, id: u64, args: &Value) -> Value {
     send(stdin, &json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -35,7 +35,7 @@ fn mcp_tool_trace_by_ulid_found() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_trace(&mut stdin, &mut reader, 2, json!({
+    let response = call_trace(&mut stdin, &mut reader, 2, &json!({
         "query": "01AAAAAAAAAAAAAAAAAAAAAAAA"
     }));
 
@@ -66,7 +66,7 @@ fn mcp_tool_trace_by_ulid_not_found() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_trace(&mut stdin, &mut reader, 2, json!({
+    let response = call_trace(&mut stdin, &mut reader, 2, &json!({
         "query": "01ZZZZZZZZZZZZZZZZZZZZZZZZ"
     }));
 
@@ -97,7 +97,7 @@ fn mcp_tool_trace_by_file_found() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_trace(&mut stdin, &mut reader, 2, json!({
+    let response = call_trace(&mut stdin, &mut reader, 2, &json!({
         "query": "src/main.rs"
     }));
 
@@ -128,7 +128,7 @@ fn mcp_tool_trace_file_not_found() {
     let mut reader = BufReader::new(child.stdout.take().unwrap());
     initialize(&mut stdin, &mut reader);
 
-    let response = call_trace(&mut stdin, &mut reader, 2, json!({
+    let response = call_trace(&mut stdin, &mut reader, 2, &json!({
         "query": "src/nonexistent.rs"
     }));
 


### PR DESCRIPTION
## Summary

- Fix `#[cfg(unix)]` test functions that fail to compile on Linux:
  - `cli_coverage.rs`: `write_config` called with 4 args (definition takes 3)
  - `cli_health_check.rs`: calls to undefined `fresh_index_timestamp` / `make_index_json` — replaced with existing helpers `write_index_json` + `recent_timestamp()`
- Fix all remaining `cargo clippy --all-targets` pedantic/nursery/all lints across 15 files

## Test plan

- [x] `cargo clippy --all-targets` passes cleanly on Windows
- [x] `cargo test` — all 289 tests pass
- [ ] Verify Linux CI passes (the `#[cfg(unix)]` fixes cannot be tested locally on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)