### PR TITLE
fix: skip permission-based tests when running as root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "assert_fs",
  "chrono",
  "clap",
+ "libc",
  "predicates",
  "rmcp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_yml = "0.0.12"
 [dev-dependencies]
 assert_cmd = "2"
 assert_fs = "1"
+libc = "0.2"
 predicates = "3"
 
 [lints.clippy]

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -1,4 +1,5 @@
 // @specre 01KHFEA9QVV4A127VCRJY97A68
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -330,6 +331,9 @@ fn coverage_full_no_uncovered_section() {
 #[test]
 fn coverage_warns_on_unreadable_source_file() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config_with_ext(tmp.path(), "docs/specres", &["src"], &["rs"]);

--- a/tests/cli_health_check.rs
+++ b/tests/cli_health_check.rs
@@ -1,4 +1,5 @@
 // @specre 01KHFGVXWP100JXYBZTRJGMB9H
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -491,6 +492,9 @@ fn health_check_malformed_index_json() {
 #[test]
 fn health_check_warns_on_unreadable_index_json() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config(tmp.path(), "docs/specres", &["src"]);

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -1,4 +1,5 @@
 // @specre 01KHAKAYN5WPTDVR99D5Q5TMJE
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -690,6 +691,9 @@ fn index_warns_on_unreadable_source_file() {
 #[test]
 fn index_warns_on_permission_denied_specre_file() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     let specre_dir = tmp.path().join("docs/specres/cli");
@@ -744,6 +748,9 @@ fn index_warns_on_permission_denied_specre_file() {
 #[test]
 fn index_warns_on_unreadable_directory() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     let specre_dir = tmp.path().join("docs/specres");
@@ -798,6 +805,9 @@ fn index_warns_on_unreadable_directory() {
 #[test]
 fn index_warns_on_unreadable_source_file_permission() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     let specre_dir = tmp.path().join("docs/specres/cli");

--- a/tests/cli_orphans.rs
+++ b/tests/cli_orphans.rs
@@ -1,4 +1,5 @@
 // @specre 01KHB48EES4FR5TFV6ZP2W3MGT
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -420,6 +421,9 @@ fn orphans_target_extensions_hides_dangling_in_non_target_files() {
 #[test]
 fn orphans_warns_on_unreadable_source_file() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config(tmp.path(), "docs/specres", &["src"]);

--- a/tests/cli_search.rs
+++ b/tests/cli_search.rs
@@ -1,5 +1,6 @@
 // @specre 01KHFTCYJN8YJMW2RNHJTAQV49
 // @specre 01KHQBKWZY2D77XP7A50HGTZQ8
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -1158,6 +1159,9 @@ fn search_single_keyword_same_with_or_without_or_flag() {
 #[test]
 fn search_warns_on_unreadable_specre_card() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config(&tmp, "docs/specres", &["src"]);

--- a/tests/cli_tag.rs
+++ b/tests/cli_tag.rs
@@ -1,4 +1,5 @@
 // @specre 01KHB48EYB9686YYQMYFYQ5R1Z
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use assert_fs::prelude::*;
@@ -665,6 +666,9 @@ fn tag_unsupported_extension_does_not_modify_file() {
 
 #[test]
 fn tag_shows_path_in_io_error() {
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
     let tmp = TempDir::new().unwrap();
     let file = tmp.child("src/readonly.rs");
     file.write_str("fn main() {}\n").unwrap();

--- a/tests/cli_trace.rs
+++ b/tests/cli_trace.rs
@@ -1,4 +1,5 @@
 // @specre 01KHB48DYZDN8GHXPX7MSYJ1NZ
+mod common;
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::TempDir;
 use predicates::prelude::*;
@@ -581,6 +582,9 @@ fn trace_file_path_ignores_target_extensions() {
 #[test]
 fn trace_ulid_warns_on_unreadable_specre_file() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config(tmp.path(), "docs/specres", &["src"]);
@@ -619,6 +623,9 @@ fn trace_ulid_warns_on_unreadable_specre_file() {
 #[test]
 fn trace_ulid_warns_on_unreadable_source_file() {
     use std::os::unix::fs::PermissionsExt;
+    if common::is_root() {
+        return; // root bypasses file-permission checks
+    }
 
     let tmp = TempDir::new().unwrap();
     write_config(tmp.path(), "docs/specres", &["src"]);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,15 @@
+/// Returns `true` when the process runs as root (effective UID 0).
+///
+/// Root bypasses POSIX file-permission checks, making permission-based
+/// tests meaningless.  Call this at the top of such tests and `return`
+/// early when it is `true`.
+#[cfg(unix)]
+pub fn is_root() -> bool {
+    // SAFETY: `geteuid` is a trivial, always-safe POSIX syscall.
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(not(unix))]
+pub fn is_root() -> bool {
+    false
+}


### PR DESCRIPTION
Root (euid 0) bypasses POSIX file-permission checks, causing 10
integration tests to fail in root environments (e.g. Docker, CI
containers). Add a `common::is_root()` guard via `libc::geteuid()`
that returns early from these tests when running as root.

https://claude.ai/code/session_01CKju4yPwBnKMHNxK2593Em