### PR TITLE
docs: add Pre-PR Quality Gate (clippy --all-targets + cargo fmt) to workflows

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,8 +13,11 @@ Follow these phases strictly.
 3. Calculate the new version (use $ARGUMENTS if provided, otherwise increment the patch version)
 4. Create a branch: `chore/bump-version-v<NEW_VERSION>`
 5. Update `version` in `Cargo.toml`
-6. Run `cargo build` to update `Cargo.lock`
-7. Commit `Cargo.toml` and `Cargo.lock`
+6. Run the **Pre-PR Quality Gate** (all three must pass before committing):
+   1. `cargo fmt --all` — auto-format all code
+   2. `cargo clippy --all-targets -- -D warnings` — lint all targets (lib, bins, tests, examples, benches)
+   3. `cargo test` — run all tests
+7. Commit `Cargo.toml`, `Cargo.lock`, and any formatting fixes
 8. Push the branch and create a PR using `gh pr create`
 
 ## --- CHECKPOINT: PR merge ---

--- a/.claude/commands/sdd-code-quality.md
+++ b/.claude/commands/sdd-code-quality.md
@@ -74,6 +74,10 @@ For each affected file:
 ## Phase 4: Finalize & PR
 
 1. Run `specre index`
-2. Commit all remaining changes
-3. Push the branch and create a Pull Request using `gh pr create`
-4. Notify the user that the workflow is complete
+2. Run the **Pre-PR Quality Gate** (all three must pass before committing):
+   1. `cargo fmt --all` — auto-format all code
+   2. `cargo clippy --all-targets -- -D warnings` — lint all targets (lib, bins, tests, examples, benches)
+   3. `cargo test` — run all tests
+3. Commit all remaining changes
+4. Push the branch and create a Pull Request using `gh pr create`
+5. Notify the user that the workflow is complete

--- a/.claude/commands/sdd-fix.md
+++ b/.claude/commands/sdd-fix.md
@@ -50,6 +50,10 @@ Notify the user that the checkpoint has been reached (if a notification script i
 
 1. Update the specre card: set `status: "stable"` and `last_verified` to today's date
 2. Run `specre index`
-3. Create a feature branch from `main` with a descriptive name (e.g., `fix/<specre-name>-<short-description>`)
-4. Commit all changes with a descriptive message
-5. Push the branch and create a Pull Request using `gh pr create`
+3. Run the **Pre-PR Quality Gate** (all three must pass before committing):
+   1. `cargo fmt --all` — auto-format all code
+   2. `cargo clippy --all-targets -- -D warnings` — lint all targets (lib, bins, tests, examples, benches)
+   3. `cargo test` — run all tests
+4. Create a feature branch from `main` with a descriptive name (e.g., `fix/<specre-name>-<short-description>`)
+5. Commit all changes with a descriptive message
+6. Push the branch and create a Pull Request using `gh pr create`

--- a/.claude/commands/sdd-new.md
+++ b/.claude/commands/sdd-new.md
@@ -52,6 +52,10 @@ Notify the user that the checkpoint has been reached (if a notification script i
 
 1. Update the specre card: set `status: "stable"` and `last_verified` to today's date
 2. Run `specre index`
-3. Create a feature branch from `main` with a descriptive name (e.g., `feature/<specre-name>`)
-4. Commit all changes with a descriptive message
-5. Push the branch and create a Pull Request using `gh pr create`
+3. Run the **Pre-PR Quality Gate** (all three must pass before committing):
+   1. `cargo fmt --all` — auto-format all code
+   2. `cargo clippy --all-targets -- -D warnings` — lint all targets (lib, bins, tests, examples, benches)
+   3. `cargo test` — run all tests
+4. Create a feature branch from `main` with a descriptive name (e.g., `feature/<specre-name>`)
+5. Commit all changes with a descriptive message
+6. Push the branch and create a Pull Request using `gh pr create`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,21 @@ last_verified: "2026-03-01"            # YYYY-MM-DD (required for stable)
 - **ULID:** 26-character identifiers generated via the `ulid` crate. Used as the single key for bidirectional traceability.
 - **Traceability:** Source files reference specres via `// @specre <ULID>` comments. specre cards reference source files in the "Related Files" section.
 
+## Pre-PR Quality Gate
+
+Before creating a Pull Request (or pushing commits intended for PR), **always** run the following checks and fix any issues. These mirror the CI pipeline exactly — if they pass locally, CI will pass.
+
+```bash
+cargo fmt --all                            # Auto-format all code
+cargo clippy --all-targets -- -D warnings  # Lint all targets (lib, bins, tests, examples, benches)
+cargo test                                 # Run all tests
+```
+
+**Order matters:** Run `cargo fmt` first (formatting changes may affect clippy results), then `cargo clippy`, then `cargo test`. All three must pass with zero warnings before committing.
+
+- `cargo clippy --all-targets` ensures clippy checks not only `src/` but also integration tests in `tests/`, examples, and benchmarks. Omitting `--all-targets` can let lint violations in test code slip through.
+- `cargo fmt --all` formats the entire workspace. CI runs `cargo fmt --all -- --check` and will reject unformatted code.
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
Add explicit instructions to run `cargo fmt --all` and
`cargo clippy --all-targets -- -D warnings` before every PR creation,
mirroring the CI pipeline exactly. This ensures agents produce
CI-passing commits without manual intervention.

Updated files:
- CLAUDE.md: new "Pre-PR Quality Gate" section with ordered steps
- sdd-new.md: Phase 4 now includes quality gate before commit
- sdd-fix.md: Phase 4 now includes quality gate before commit
- sdd-code-quality.md: Phase 4 now includes quality gate before commit
- release.md: Phase 1 now includes quality gate before version bump PR

https://claude.ai/code/session_01H7CsYBTdEy6DnVdjj1ivSS