### PR TITLE
chore: tag tests/common/mod.rs to achieve full specre coverage

### DIFF
--- a/docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md
+++ b/docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md
@@ -11,6 +11,7 @@ last_verified: "2026-02-15"
 - `src/cli.rs`
 - `src/commands/mod.rs`
 - `tests/cli_dispatch.rs` (Test)
+- `tests/common/mod.rs` (Test helper)
 
 ## Functional Overview
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-18T09:12:33Z",
+  "generated_at": "2026-02-18T23:31:03Z",
   "source_refs": [
     {
       "file": "src/card.rs",
@@ -405,6 +405,11 @@
       "file": "tests/cli_trace.rs",
       "line": 1,
       "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ"
+    },
+    {
+      "file": "tests/common/mod.rs",
+      "line": 1,
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
     },
     {
       "file": "tests/mcp/helpers.rs",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+// @specre 01KHFFCX8BCDAYP8YHG0J65H0E
 /// Returns `true` when the process runs as root (effective UID 0).
 ///
 /// Root bypasses POSIX file-permission checks, making permission-based


### PR DESCRIPTION
## Summary

- Add `@specre 01KHFFCX8BCDAYP8YHG0J65H0E` marker to `tests/common/mod.rs`
- Add `tests/common/mod.rs` to the Related Files section of `specre_cli_dispatches_commands_and_handles_errors.md`
- Regenerate `docs/specres/index.json`

This brings specre coverage from 0.98 → 1.0, allowing `health-check` to return `healthy: true`.

## Test plan

- [x] `specre health-check` → `healthy: true`, `coverage: 1.0`
- [x] `specre coverage` → `tagged: 52 / total: 52`
- [x] `specre orphans` → no orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)