### PR TITLE
docs: add v0.6 (multi-repo traceability) and v0.7 (remote resolution) to roadmap

### DIFF
--- a/docs/project/ROADMAP.ja.md
+++ b/docs/project/ROADMAP.ja.md
@@ -89,6 +89,84 @@ QA エンジニアが specre カードと直接作業するための決定論的
 - [ ] `specre diff [specre-path]` — git 履歴を使用して、最後の `stable` 状態以降の specre カードの変更を表示。`specre drift`（*何か*が変更されたかを検出）を補完し、*何が*変更されたかを表示できる。
 - [ ] `specre export [--format <fmt>]` — Scenarios セクションを構造化されたテストケースフォーマット（Markdown チェックリスト、CSV）に変換し、テスト管理ツールへのインポートを可能に。仕様からテストケースへの手動転写を排除できる。
 
+## v0.6 — マルチリポジトリ・トレーサビリティ
+
+リポジトリ境界を越えた specre のトレーサビリティを実現する。ポリレポ構成のマイクロサービス、フロントエンド/バックエンド分離、イベント駆動アーキテクチャに対応。
+
+### 設計原則: Provider が所有し、Consumer が外部参照する
+
+サービス境界をまたぐ振る舞い（API コントラクト、イベントスキーマ、共有 DTO）には自然な所有権モデルがある。**提供側（Provider）が specre カードを所有し、消費側（Consumer）がそれを外部参照する。** これにより重複を避け、各コントラクトの唯一の情報源を確立する。
+
+```
+orders-service (Provider)              frontend-app (Consumer)
+┌─────────────────────────────────┐   ┌──────────────────────────────────┐
+│ docs/specres/api/               │   │ src/api/orders.ts                │
+│   order_api_returns_order_dto.md│   │   // @specre-ext 01XYZ... orders │
+│   (id: 01XYZ..., status: stable)│   │   interface OrderDto { ... }     │
+│                                 │   │                                  │
+│ src/handlers/orders.rs          │   │                                  │
+│   // @specre 01XYZ...           │   │                                  │
+└─────────────────────────────────┘   └──────────────────────────────────┘
+```
+
+### 設計原則: 宣言と解決を分離する
+
+マルチリポジトリ設定には、混同してはならない2つの関心事がある:
+
+- **宣言**（どのリモートが存在するか） — git にコミットし、チーム全体で共有
+- **解決**（リモートがこのマシンのどこにあるか） — ローカル、個人管理、git で追跡しない
+
+この分離は実際のチーム開発で極めて重要である。20人規模のプロダクトチームが4つのスクラムチームで運営される場合、サービス間連携に携わるのは通常1チームのみ。他のチームは関連リポジトリをチェックアウトすらしていないことがある。未解決の外部参照がプロジェクトを「unhealthy」にしてしまうと、大半の開発者が常に赤いステータスを見ることになり、health-check の存在意義が根本から崩れる。
+
+**`specre.toml`（コミット対象）:**
+
+```toml
+[remotes.orders-api]
+git = "https://github.com/org/orders-service.git"
+specre_dir = "docs/specres"
+```
+
+**`.specre.local.toml`（`.gitignore` 対象、個人管理）:**
+
+```toml
+[remotes.orders-api]
+path = "../orders-service"
+```
+
+### 設計原則: 未解決の外部参照は unhealthy ではない
+
+`specre health-check` は**ローカル**の specre エコシステムのみを判定する。外部参照の解決状況は別セクションで報告されるが、`healthy` フラグには影響しない。
+
+```
+Local ecosystem:
+  healthy: true
+
+External references:
+  @specre-ext markers: 3
+  resolved: 1 / unresolved: 2
+```
+
+### 計画
+
+- [ ] `@specre-ext <ULID> [origin]` マーカー — `@specre` とは明確に区別される新しいマーカー型。参照先の仕様が別プロジェクトに存在することを示す。origin ヒントは省略可能だが、解決速度の向上とドキュメントとしての価値がある
+- [ ] `specre.toml [remotes]` セクション — 正規の git URL でリモート specre ソースを宣言。ローカルパスはここに書かない（`.specre.local.toml` に記述）
+- [ ] `.specre.local.toml` サポート — 個人管理の gitignore 対象ファイル。リモートのローカルパス解決を提供
+- [ ] `specre trace` 拡張 — 設定済みリモート経由で `@specre-ext` マーカーを解決し、出力に `(ext)` 注釈を表示
+- [ ] `specre orphans` 拡張 — リモート未設定の `@specre-ext` マーカーは情報表示扱い（エラーではない）
+- [ ] `specre coverage` 拡張 — `@specre-ext` マーカーもカバレッジとしてカウント
+- [ ] `specre health-check` 拡張 — 外部参照を別セクションで報告。未解決の外部参照は `healthy` に影響しない
+
+## v0.7 — リモート解決とサービス境界管理
+
+v0.6 のマルチリポジトリ基盤の上に、ネットワーク経由の解決とクロスリポジトリのコントラクト管理ツールを構築する。
+
+- [ ] `specre fetch [remote-name | --all]` — リポジトリ全体をクローンせずにリモートの specre ディレクトリを取得（sparse-checkout または GitHub API）。`.specre-cache/`（gitignore 対象、ローカル）に保存
+- [ ] `specre fetch --status` — 全宣言済みリモートのキャッシュ鮮度を報告
+- [ ] `specre boundary` — プロジェクト全体の外部参照一覧、解決状況、依存するリモートを表示
+- [ ] `specre boundary --check` — クロスリポジトリのコントラクト健全性の明示的な検証（インテグレーションチームおよび CI 向け）
+- [ ] `[remotes]` git 解決 — `.specre.local.toml` のパスが未設定の場合、git URL から直接リモート specre カードを解決（`.specre-cache/` を使用）
+- [ ] クロスリポジトリ `specre drift` — ローカルコードが依存するリモート specre カードの `last_verified` 鮮度を検証
+
 ## 将来の検討事項
 
 - カスタム front matter フィールド（`type`、`tags` など）のプラグインシステム（オプションのバリデーション付き） — プロジェクト定義の語彙で `specre search --tag "quotation edit"` のような検索を可能に

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -89,6 +89,84 @@ Deterministic CLI commands that help QA engineers work directly with specre card
 - [ ] `specre diff [specre-path]` — Show how a specre card has changed since its last `stable` state, using git history. Complements `specre drift` (which detects *whether* something changed) by showing *what* changed.
 - [ ] `specre export [--format <fmt>]` — Convert Scenarios sections into structured test case formats (Markdown checklist, CSV) for import into test management tools. Eliminates the manual transcription of specifications into test cases.
 
+## v0.6 — Multi-Repository Traceability
+
+Enable specre traceability across repository boundaries — for polyrepo microservices, separate frontend/backend repos, and event-driven architectures.
+
+### Design principle: Provider Owns, Consumer References
+
+A behavior that spans service boundaries (API contracts, event schemas, shared DTOs) has a natural ownership model: **the provider owns the specre card, the consumer references it externally**. This avoids duplication and establishes a single source of truth for each contract.
+
+```
+orders-service (Provider)              frontend-app (Consumer)
+┌─────────────────────────────────┐   ┌──────────────────────────────────┐
+│ docs/specres/api/               │   │ src/api/orders.ts                │
+│   order_api_returns_order_dto.md│   │   // @specre-ext 01XYZ... orders │
+│   (id: 01XYZ..., status: stable)│   │   interface OrderDto { ... }     │
+│                                 │   │                                  │
+│ src/handlers/orders.rs          │   │                                  │
+│   // @specre 01XYZ...           │   │                                  │
+└─────────────────────────────────┘   └──────────────────────────────────┘
+```
+
+### Design principle: Separate Declaration from Resolution
+
+Multi-repo configuration has two distinct concerns that must not be conflated:
+
+- **Declaration** (what remotes exist) — committed to git, shared across the team
+- **Resolution** (where remotes are on this machine) — local, personal, not tracked by git
+
+This separation is critical for real-world team dynamics. In a 20-person product team with 4 scrum teams, typically only one team works on cross-service integration. The other teams may not even have related repositories checked out. If unresolved external references made the project "unhealthy," most developers would see perpetual red status — which defeats the purpose of health-check entirely.
+
+**`specre.toml` (committed):**
+
+```toml
+[remotes.orders-api]
+git = "https://github.com/org/orders-service.git"
+specre_dir = "docs/specres"
+```
+
+**`.specre.local.toml` (in `.gitignore`, personal):**
+
+```toml
+[remotes.orders-api]
+path = "../orders-service"
+```
+
+### Design principle: Unresolved externals are not unhealthy
+
+`specre health-check` judges only the **local** specre ecosystem. External reference resolution status is reported separately and does not affect the `healthy` flag.
+
+```
+Local ecosystem:
+  healthy: true
+
+External references:
+  @specre-ext markers: 3
+  resolved: 1 / unresolved: 2
+```
+
+### Planned work
+
+- [ ] `@specre-ext <ULID> [origin]` marker — A new marker type, distinct from `@specre`, indicating that the referenced spec lives in another project. The origin hint is optional but aids resolution speed and serves as documentation
+- [ ] `specre.toml [remotes]` section — Declare remote specre sources with canonical git URLs. No local paths here (those go in `.specre.local.toml`)
+- [ ] `.specre.local.toml` support — Personal, gitignored file that provides local path overrides for remotes
+- [ ] `specre trace` extended — Resolve `@specre-ext` markers via configured remotes; display `(ext)` annotations in output
+- [ ] `specre orphans` extended — `@specre-ext` markers with unresolved remotes are informational, not errors
+- [ ] `specre coverage` extended — Count `@specre-ext` markers as coverage
+- [ ] `specre health-check` extended — Report external references in a separate section; do not let unresolved externals affect `healthy`
+
+## v0.7 — Remote Resolution & Boundary Management
+
+Build on v0.6's multi-repo foundation with network-based resolution and cross-repo contract management tooling.
+
+- [ ] `specre fetch [remote-name | --all]` — Fetch remote specre directories without cloning entire repositories (sparse-checkout or GitHub API). Store in `.specre-cache/` (gitignored, local)
+- [ ] `specre fetch --status` — Report cache freshness for all declared remotes
+- [ ] `specre boundary` — List all external references across the project, their resolution status, and which remotes they depend on
+- [ ] `specre boundary --check` — Explicit opt-in validation of cross-repo contract health (for integration teams and CI)
+- [ ] `[remotes]` git resolution — Resolve remote specre cards directly from git URLs when `.specre.local.toml` paths are not configured, using the `.specre-cache/`
+- [ ] Cross-repo `specre drift` — Check `last_verified` freshness of remote specre cards that local code depends on
+
 ## Future Considerations
 
 - Plugin system for custom front-matter fields (`type`, `tags`, etc.) with optional validation — enabling searches like `specre search --tag "quotation edit"` across project-defined vocabularies


### PR DESCRIPTION
Design decisions documented:
- @specre-ext marker for cross-repo references (distinct from @specre)
- Provider-owns-consumer-references ownership model
- Declaration (specre.toml, committed) vs Resolution (.specre.local.toml, gitignored)
- Unresolved external references do not affect health-check healthy status
- specre fetch for lightweight remote spec retrieval
- specre boundary for cross-repo contract management

https://claude.ai/code/session_01FmcAQj2PGEVYK76mcHjK44