### PR TITLE
fix: skip binary files silently in source scanner

### DIFF
--- a/docs/specres/cli/_INDEX.md
+++ b/docs/specres/cli/_INDEX.md
@@ -7,10 +7,10 @@
 | [specre_index_generates_project_index](specre_index_generates_project_index.md) | stable | 2026-02-18 |
 | [specre_status_reports_project_health](specre_status_reports_project_health.md) | stable | 2026-02-17 |
 | [specre_trace_resolves_bidirectional_references](specre_trace_resolves_bidirectional_references.md) | stable | 2026-02-17 |
-| [specre_orphans_detects_unlinked_specres_and_markers](specre_orphans_detects_unlinked_specres_and_markers.md) | stable | 2026-02-18 |
+| [specre_orphans_detects_unlinked_specres_and_markers](specre_orphans_detects_unlinked_specres_and_markers.md) | stable | 2026-02-22 |
 | [specre_tag_inserts_marker_into_source_file](specre_tag_inserts_marker_into_source_file.md) | stable | 2026-02-17 |
 | [user_can_set_language_config](user_can_set_language_config.md) | stable | 2026-02-14 |
-| [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-17 |
+| [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-22 |
 | [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-18 |
 | [specre_cli_dispatches_commands_and_handles_errors](specre_cli_dispatches_commands_and_handles_errors.md) | stable | 2026-02-15 |
 | [specre_health_check_verifies_ecosystem_trustworthiness](specre_health_check_verifies_ecosystem_trustworthiness.md) | stable | 2026-02-18 |

--- a/docs/specres/cli/specre_orphans_detects_unlinked_specres_and_markers.md
+++ b/docs/specres/cli/specre_orphans_detects_unlinked_specres_and_markers.md
@@ -2,7 +2,7 @@
 id: "01KHB48EES4FR5TFV6ZP2W3MGT"
 name: "specre_orphans_detects_unlinked_specres_and_markers"
 status: "stable"
-last_verified: "2026-02-18"
+last_verified: "2026-02-22"
 ---
 
 ## Related Files
@@ -14,7 +14,7 @@ last_verified: "2026-02-18"
 
 ## Functional Overview
 
-`specre orphans` detects specres that have no `@specre` markers in any source file (orphan specres) and `@specre` markers in source files that do not match any specre's `id` (dangling markers). It reports both categories so developers can restore traceability or clean up stale references. Source file scanning respects the `target_extensions` setting in `specre.toml` when configured.
+`specre orphans` detects specres that have no `@specre` markers in any source file (orphan specres) and `@specre` markers in source files that do not match any specre's `id` (dangling markers). It reports both categories so developers can restore traceability or clean up stale references. Source file scanning respects the `target_extensions` setting in `specre.toml` when configured. Binary (non-UTF-8) files are always skipped silently, regardless of `target_extensions` configuration.
 
 ## Design Intent
 
@@ -86,6 +86,14 @@ The primary consumers are CI pipelines (where a non-zero exit code can block mer
 
 1. User runs `specre orphans` in a directory without `specre.toml`
 2. CLI exits with error: `Error: specre.toml not found. Run 'specre init' first.`
+
+### Binary files in source directories are skipped
+
+1. A project has `source_dirs = ["src"]` without `target_extensions`
+2. `src/` contains a binary file `logo.png` (non-UTF-8)
+3. User runs `specre orphans`
+4. The binary file is silently skipped — no warning on stderr, not counted as a scanned file
+5. Orphan and dangling marker detection proceeds using only text files
 
 ### Empty project
 

--- a/docs/specres/cli/user_can_set_target_extensions.md
+++ b/docs/specres/cli/user_can_set_target_extensions.md
@@ -2,7 +2,7 @@
 id: "01KHFD5R1G3C5R34XMQXQTTMM9"
 name: "user_can_set_target_extensions"
 status: "stable"
-last_verified: "2026-02-17"
+last_verified: "2026-02-22"
 ---
 
 ## Related Files
@@ -16,13 +16,13 @@ last_verified: "2026-02-17"
 
 ## Functional Overview
 
-Users can configure `target_extensions` in `specre.toml` to restrict which source files are scanned for `@specre` markers. When set, only files whose extension matches the list are scanned by `index`, `orphans`, and `trace`. When unset, all files are scanned (preserving backward compatibility). The `specre init` command accepts a `--ext` flag to configure this setting at project initialization.
+Users can configure `target_extensions` in `specre.toml` to restrict which source files are scanned for `@specre` markers. When set, only files whose extension matches the list are scanned by `index`, `orphans`, and `trace`. When unset, all text files are scanned (binary files that fail UTF-8 decoding are always skipped silently). The `specre init` command accepts a `--ext` flag to configure this setting at project initialization.
 
 ## Design Intent
 
-Without extension filtering, specre scans every file in `source_dirs` — including binary files, images, lock files, and other non-source artifacts. This wastes time and can produce false positives if a binary file happens to contain a byte sequence matching the `@specre` pattern. The `target_extensions` setting lets users declare which file types constitute their source code, improving both performance and accuracy.
+Without extension filtering, specre scans every text file in `source_dirs`. Binary files (images, fonts, lock files, and other non-UTF-8 artifacts) are always skipped silently — they cannot contain `@specre` markers and scanning them wastes time. The `target_extensions` setting lets users further restrict which text file types constitute their source code, improving both performance and accuracy.
 
-This setting is project-level because the set of relevant source extensions is stable within a project (e.g., a Rust project always targets `.rs`). Making it a config value avoids repeating `--ext` on every command invocation. The setting is optional and defaults to scanning all files, ensuring zero friction for new users and full backward compatibility for existing projects.
+This setting is project-level because the set of relevant source extensions is stable within a project (e.g., a Rust project always targets `.rs`). Making it a config value avoids repeating `--ext` on every command invocation. The setting is optional and defaults to scanning all text files, ensuring zero friction for new users and full backward compatibility for existing projects.
 
 ## Key Members
 
@@ -37,7 +37,7 @@ This setting is project-level because the set of relevant source extensions is s
 2. `specre.toml` is created without a `target_extensions` field
 3. User runs `specre index`
 4. CLI reads `specre.toml`, finds no `target_extensions` field
-5. CLI scans all files in `source_dirs` for `@specre` markers (same as current behavior)
+5. CLI scans all text files in `source_dirs` for `@specre` markers; binary (non-UTF-8) files are skipped silently
 
 ### Init with target extensions
 
@@ -54,7 +54,7 @@ This setting is project-level because the set of relevant source extensions is s
 2. User updates specre binary to the new version
 3. User runs `specre index`
 4. CLI reads `specre.toml`, `target_extensions` field is missing
-5. All files in `source_dirs` are scanned — same behavior as before
+5. All text files in `source_dirs` are scanned; binary files are skipped silently
 
 ### Extensions are specified without leading dots
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-18T23:31:03Z",
+  "generated_at": "2026-02-22T05:05:40Z",
   "source_refs": [
     {
       "file": "src/card.rs",
@@ -621,7 +621,7 @@
     {
       "domain": "cli",
       "id": "01KHB48EES4FR5TFV6ZP2W3MGT",
-      "last_verified": "2026-02-18",
+      "last_verified": "2026-02-22",
       "name": "specre_orphans_detects_unlinked_specres_and_markers",
       "path": "docs/specres/cli/specre_orphans_detects_unlinked_specres_and_markers.md",
       "status": "stable"
@@ -645,7 +645,7 @@
     {
       "domain": "cli",
       "id": "01KHFD5R1G3C5R34XMQXQTTMM9",
-      "last_verified": "2026-02-17",
+      "last_verified": "2026-02-22",
       "name": "user_can_set_target_extensions",
       "path": "docs/specres/cli/user_can_set_target_extensions.md",
       "status": "stable"

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -139,15 +139,20 @@ pub fn scan_source_markers(
             continue;
         }
         collect_all_files(dir, target_extensions, &mut |path| {
-            total += 1;
             let content = match fs::read_to_string(path) {
                 Ok(c) => c,
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                    // Binary (non-UTF-8) file — skip silently
+                    return;
+                }
                 Err(e) => {
+                    total += 1;
                     eprintln!("Warning: failed to read '{}': {e}", path.display());
                     uncovered.push(to_forward_slash(path).into_owned());
                     return;
                 }
             };
+            total += 1;
             let rel_path = to_forward_slash(path).into_owned();
             let mut file_has_marker = false;
             for (line_num, line) in content.lines().enumerate() {

--- a/tests/cli_orphans.rs
+++ b/tests/cli_orphans.rs
@@ -418,6 +418,50 @@ fn orphans_target_extensions_hides_dangling_in_non_target_files() {
         ));
 }
 
+// -- Scenario: Binary files in source directories are skipped --
+
+#[test]
+fn orphans_skips_binary_files_silently() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+    );
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // Write a binary file (invalid UTF-8) into src/
+    let binary_path = tmp.path().join("src/logo.png");
+    fs::write(&binary_path, b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00").unwrap();
+
+    let output = specre()
+        .args(["orphans"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Binary file should not produce any warning on stderr
+    assert!(
+        !stderr.contains("Warning"),
+        "Binary file should not produce a warning, got: {stderr}"
+    );
+    // Orphan detection should still work correctly
+    assert!(
+        stdout.contains("No orphans or dangling markers found."),
+        "Expected clean orphans output, got: {stdout}"
+    );
+    assert!(output.status.success());
+}
+
 // -- Failures / Exceptions: IO error warns and skips --
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- `scan_source_markers` in `scanner.rs` now silently skips binary (non-UTF-8) files instead of printing warnings and counting them as uncovered
- Affects all commands sharing the scanner: `orphans`, `coverage`, `health-check`, `index`
- When `target_extensions` is not configured, binary files (images, fonts, etc.) are no longer processed — only text files are scanned
- When `target_extensions` is configured, behavior is unchanged (extension filter already excluded binary files)

## Changed files

| File | Change |
|------|--------|
| `src/scanner.rs` | Skip `ErrorKind::InvalidData` (non-UTF-8) silently; move `total` increment after successful read |
| `tests/cli_orphans.rs` | New test `orphans_skips_binary_files_silently` |
| `docs/specres/cli/specre_orphans_detects_unlinked_specres_and_markers.md` | Added "Binary files in source directories are skipped" scenario |
| `docs/specres/cli/user_can_set_target_extensions.md` | Updated "all files" → "all text files" in Functional Overview and scenarios |

## Test plan

- [x] New test: binary PNG in `src/` produces no warning and doesn't affect orphan detection
- [x] All 249 existing tests pass
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)