### PR TITLE
fix: truncate uncovered files list to 30 items in coverage output

### DIFF
--- a/docs/specres/cli/_INDEX.md
+++ b/docs/specres/cli/_INDEX.md
@@ -11,7 +11,7 @@
 | [specre_tag_inserts_marker_into_source_file](specre_tag_inserts_marker_into_source_file.md) | stable | 2026-02-17 |
 | [user_can_set_language_config](user_can_set_language_config.md) | stable | 2026-02-14 |
 | [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-22 |
-| [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-18 |
+| [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-22 |
 | [specre_cli_dispatches_commands_and_handles_errors](specre_cli_dispatches_commands_and_handles_errors.md) | stable | 2026-02-15 |
 | [specre_health_check_verifies_ecosystem_trustworthiness](specre_health_check_verifies_ecosystem_trustworthiness.md) | stable | 2026-02-18 |
 | [specre_search_finds_specre_cards_by_query](specre_search_finds_specre_cards_by_query.md) | stable | 2026-02-18 |

--- a/docs/specres/cli/specre_commands_support_json_output.md
+++ b/docs/specres/cli/specre_commands_support_json_output.md
@@ -131,7 +131,7 @@ The v0.3 roadmap targets agent integration. Agents need machine-readable output 
 
 ### coverage --json outputs structured JSON
 
-1. User runs `specre coverage --json`
+1. User runs `specre coverage --json` with 2 uncovered files (within the 30-item limit)
 2. CLI outputs JSON to stdout:
    ```json
    {
@@ -145,6 +145,23 @@ The v0.3 roadmap targets agent integration. Agents need machine-readable output 
    }
    ```
 3. CLI exits with exit code 0
+
+### coverage --json truncates uncovered files when too many
+
+1. User runs `specre coverage --json` with more than 30 uncovered files
+2. CLI outputs JSON to stdout with truncation metadata:
+   ```json
+   {
+     "total": 50,
+     "tagged": 1,
+     "coverage": 0.02,
+     "uncovered": ["src/a.rs", "...30 items..."],
+     "uncovered_total": 49,
+     "truncated": true
+   }
+   ```
+3. `uncovered` contains at most 30 items; `uncovered_total` is the actual count; `truncated` is `true`
+4. CLI exits with exit code 0
 
 ### coverage --json with --ext filter
 

--- a/docs/specres/cli/specre_coverage_reports_source_file_tagging.md
+++ b/docs/specres/cli/specre_coverage_reports_source_file_tagging.md
@@ -2,7 +2,7 @@
 id: "01KHFEA9QVV4A127VCRJY97A68"
 name: "specre_coverage_reports_source_file_tagging"
 status: "stable"
-last_verified: "2026-02-18"
+last_verified: "2026-02-22"
 ---
 
 ## Related Files
@@ -27,6 +27,7 @@ Coverage is a key metric for assessing traceability health. If most source files
 - **Tagged files:** the subset of total files that contain at least one `@specre <ULID>` marker
 - **Coverage percentage:** `tagged / total * 100`, displayed as a percentage with one decimal place. Derived from `CoverageResult` fields at display time.
 - `--ext` flag: comma-separated list of file extensions to filter by, overriding `target_extensions` from `specre.toml` for this invocation
+- **Uncovered files display limit:** at most 30 uncovered files are shown. When truncated, a summary line indicates the total count. This prevents excessive output from overwhelming AI agent context windows.
 
 ## Scenarios
 
@@ -87,7 +88,7 @@ Coverage is a key metric for assessing traceability health. If most source files
 
 ### Uncovered files are listed
 
-1. User runs `specre coverage` in a project with uncovered files
+1. User runs `specre coverage` in a project with uncovered files (30 or fewer)
 2. After the summary line, CLI prints uncovered files:
    ```
    Coverage: 1/3 files (33.3%)
@@ -97,6 +98,21 @@ Coverage is a key metric for assessing traceability health. If most source files
      src/baz.rs
    ```
 3. Uncovered file paths use forward slashes on all platforms and are sorted alphabetically
+
+### Too many uncovered files are truncated
+
+1. User runs `specre coverage` in a project with more than 30 uncovered files
+2. CLI prints the first 30 uncovered files followed by a truncation summary:
+   ```
+   Coverage: 1/50 files (2.0%)
+
+   Uncovered files:
+     src/a.rs
+     src/b.rs
+     ... (30 of 49 shown)
+   ```
+3. The `--json` output includes all fields: `uncovered` (truncated to 30 items), `uncovered_total` (actual count), and `truncated` (boolean)
+4. When `truncated` is false, `uncovered_total` is omitted from JSON output
 
 ### Paths use forward slashes
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-22T05:05:40Z",
+  "generated_at": "2026-02-22T08:10:37Z",
   "source_refs": [
     {
       "file": "src/card.rs",
@@ -653,7 +653,7 @@
     {
       "domain": "cli",
       "id": "01KHFEA9QVV4A127VCRJY97A68",
-      "last_verified": "2026-02-18",
+      "last_verified": "2026-02-22",
       "name": "specre_coverage_reports_source_file_tagging",
       "path": "docs/specres/cli/specre_coverage_reports_source_file_tagging.md",
       "status": "stable"

--- a/docs/specres/mcp/mcp_tool_coverage_reports_tag_coverage.md
+++ b/docs/specres/mcp/mcp_tool_coverage_reports_tag_coverage.md
@@ -27,8 +27,10 @@ No parameters.
 
 Return value:
 ```json
-{ "total": N, "tagged": N, "coverage": 0.0..1.0, "uncovered": ["<path>", ...] }
+{ "total": N, "tagged": N, "coverage": 0.0..1.0, "uncovered": ["<path>", ...], "uncovered_total": N, "truncated": bool }
 ```
+- `uncovered` contains at most 30 items
+- `uncovered_total` and `truncated` are present only when the list is truncated
 
 ## Scenarios
 
@@ -41,7 +43,8 @@ Return value:
 ### Partial coverage
 
 1. Some files lack `@specre` tags
-2. Server returns the ratio and list of uncovered files
+2. Server returns the ratio and list of uncovered files (at most 30)
+3. When more than 30 files are uncovered, `uncovered_total` and `truncated: true` are included
 
 ### No source files
 

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -6,12 +6,19 @@ use crate::error::SpecreError;
 use crate::scanner::{SourceScanResult, scan_source_markers};
 use serde::Serialize;
 
+/// Maximum number of uncovered files shown in output.
+const UNCOVERED_DISPLAY_LIMIT: usize = 30;
+
 #[derive(Serialize)]
 struct CoverageOutput {
     total: usize,
     tagged: usize,
     coverage: f64,
     uncovered: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uncovered_total: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -62,17 +69,26 @@ pub fn execute(args: CoverageArgs, json: bool) -> Result<(), SpecreError> {
 
     let result = compute_coverage(&config.source_dirs, extensions.as_deref());
 
+    let uncovered_total = result.uncovered.len();
+    let is_truncated = uncovered_total > UNCOVERED_DISPLAY_LIMIT;
+
     if json {
         let coverage_ratio = if result.total == 0 {
             0.0
         } else {
             result.tagged as f64 / result.total as f64
         };
+        let mut uncovered = result.uncovered;
+        if is_truncated {
+            uncovered.truncate(UNCOVERED_DISPLAY_LIMIT);
+        }
         let output = CoverageOutput {
             total: result.total,
             tagged: result.tagged,
             coverage: coverage_ratio,
-            uncovered: result.uncovered,
+            uncovered,
+            uncovered_total: is_truncated.then_some(uncovered_total),
+            truncated: is_truncated.then_some(true),
         };
         let json_str = serde_json::to_string_pretty(&output)?;
         println!("{json_str}");
@@ -90,8 +106,11 @@ pub fn execute(args: CoverageArgs, json: bool) -> Result<(), SpecreError> {
         if !result.uncovered.is_empty() {
             println!();
             println!("Uncovered files:");
-            for path in &result.uncovered {
+            for path in result.uncovered.iter().take(UNCOVERED_DISPLAY_LIMIT) {
                 println!("  {path}");
+            }
+            if is_truncated {
+                println!("  ... ({UNCOVERED_DISPLAY_LIMIT} of {uncovered_total} shown)");
             }
         }
     }

--- a/src/commands/mcp/helpers.rs
+++ b/src/commands/mcp/helpers.rs
@@ -479,6 +479,8 @@ pub fn execute_orphans() -> Result<CallToolResult, McpError> {
 // ---------------------------------------------------------------------------
 
 pub fn execute_coverage() -> Result<CallToolResult, McpError> {
+    const UNCOVERED_DISPLAY_LIMIT: usize = 30;
+
     let cfg = load_config()?;
     let cov = crate::commands::coverage::compute_coverage(
         &cfg.source_dirs,
@@ -491,12 +493,24 @@ pub fn execute_coverage() -> Result<CallToolResult, McpError> {
         cov.tagged as f64 / cov.total as f64
     };
 
-    let result = serde_json::json!({
+    let uncovered_total = cov.uncovered.len();
+    let is_truncated = uncovered_total > UNCOVERED_DISPLAY_LIMIT;
+    let mut uncovered = cov.uncovered;
+    if is_truncated {
+        uncovered.truncate(UNCOVERED_DISPLAY_LIMIT);
+    }
+
+    let mut result = serde_json::json!({
         "total": cov.total,
         "tagged": cov.tagged,
         "coverage": coverage_ratio,
-        "uncovered": cov.uncovered,
+        "uncovered": uncovered,
     });
+
+    if is_truncated {
+        result["uncovered_total"] = serde_json::json!(uncovered_total);
+        result["truncated"] = serde_json::json!(true);
+    }
 
     Ok(CallToolResult::success(vec![Content::text(
         result.to_string(),

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -308,6 +308,83 @@ fn coverage_skips_nonexistent_source_dirs() {
         .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
 }
 
+// -- Scenario: Too many uncovered files are truncated --
+
+#[test]
+fn coverage_truncates_uncovered_files_over_30() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+
+    // Create 1 tagged file
+    write_source(
+        tmp.path(),
+        "src/tagged.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn tagged() {}\n",
+    );
+
+    // Create 35 uncovered files
+    for i in 0..35 {
+        write_source(
+            tmp.path(),
+            &format!("src/untagged_{i:03}.rs"),
+            &format!("fn untagged_{i}() {{}}\n"),
+        );
+    }
+
+    let output = specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should show truncation summary
+    assert!(
+        stdout.contains("... (30 of 35 shown)"),
+        "Expected truncation summary, got: {stdout}"
+    );
+
+    // Should show exactly 30 uncovered file lines (not 35)
+    let uncovered_lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.trim_start().starts_with("src/"))
+        .collect();
+    assert_eq!(
+        uncovered_lines.len(),
+        30,
+        "Expected 30 uncovered files listed, got {}",
+        uncovered_lines.len()
+    );
+}
+
+#[test]
+fn coverage_shows_all_uncovered_files_at_30() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+
+    // Create exactly 30 uncovered files (no tagged files)
+    for i in 0..30 {
+        write_source(
+            tmp.path(),
+            &format!("src/file_{i:03}.rs"),
+            &format!("fn file_{i}() {{}}\n"),
+        );
+    }
+
+    let output = specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should NOT show truncation summary
+    assert!(
+        !stdout.contains("..."),
+        "Should not truncate at exactly 30 files, got: {stdout}"
+    );
+}
+
 // -- Full coverage does not show uncovered section --
 
 #[test]

--- a/tests/cli_json_output.rs
+++ b/tests/cli_json_output.rs
@@ -350,6 +350,62 @@ fn coverage_json_with_ext_filter() {
 }
 
 // ============================================================
+// coverage --json truncation
+// ============================================================
+
+#[test]
+fn coverage_json_truncates_when_over_30() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+
+    // Create 1 tagged file + 35 uncovered files
+    write_source(tmp.path(), "src/tagged.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    for i in 0..35 {
+        write_source_no_marker(tmp.path(), &format!("src/untagged_{i:03}.rs"));
+    }
+
+    let assert = specre()
+        .args(["coverage", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert_eq!(json["total"], 36);
+    assert_eq!(json["tagged"], 1);
+
+    let uncovered = json["uncovered"].as_array().unwrap();
+    assert_eq!(uncovered.len(), 30, "uncovered should be truncated to 30");
+
+    assert_eq!(json["uncovered_total"], 35);
+    assert_eq!(json["truncated"], true);
+}
+
+#[test]
+fn coverage_json_no_truncation_metadata_when_within_limit() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres");
+    write_source(tmp.path(), "src/tagged.rs", "01AAAAAAAAAAAAAAAAAAAAAAAA");
+    write_source_no_marker(tmp.path(), "src/untagged.rs");
+
+    let assert = specre()
+        .args(["coverage", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json = parse_json(&assert);
+    assert!(
+        json.get("uncovered_total").is_none(),
+        "uncovered_total should be absent when not truncated"
+    );
+    assert!(
+        json.get("truncated").is_none(),
+        "truncated should be absent when not truncated"
+    );
+}
+
+// ============================================================
 // init --json
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Cap the uncovered files list at 30 entries in `specre coverage` output (CLI text, JSON, and MCP tool)
- When truncated, CLI text shows `... (30 of N shown)`; JSON/MCP adds `uncovered_total` and `truncated` fields
- Prevents excessive output from overwhelming AI agent context windows

## Test plan
- [x] New test: `coverage_truncates_uncovered_files_over_30` — 35 uncovered files, verifies 30 shown + summary
- [x] New test: `coverage_shows_all_uncovered_files_at_30` — exactly 30 files, verifies no truncation
- [x] New test: `coverage_json_truncates_when_over_30` — JSON output with truncation metadata
- [x] New test: `coverage_json_no_truncation_metadata_when_within_limit` — no extra fields when ≤30
- [x] All 255 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)