### PR TITLE
fix: exclude dot files and SVG from source scanner

### DIFF
--- a/docs/specres/cli/user_can_set_target_extensions.md
+++ b/docs/specres/cli/user_can_set_target_extensions.md
@@ -18,16 +18,21 @@ last_verified: "2026-02-22"
 
 Users can configure `target_extensions` in `specre.toml` to restrict which source files are scanned for `@specre` markers. When set, only files whose extension matches the list are scanned by `index`, `orphans`, and `trace`. When unset, all text files are scanned (binary files that fail UTF-8 decoding are always skipped silently). The `specre init` command accepts a `--ext` flag to configure this setting at project initialization.
 
+Additionally, dot files (files whose names start with `.`) and `.svg` files are unconditionally excluded from scanning regardless of `target_extensions`.
+
 ## Design Intent
 
 Without extension filtering, specre scans every text file in `source_dirs`. Binary files (images, fonts, lock files, and other non-UTF-8 artifacts) are always skipped silently — they cannot contain `@specre` markers and scanning them wastes time. The `target_extensions` setting lets users further restrict which text file types constitute their source code, improving both performance and accuracy.
 
 This setting is project-level because the set of relevant source extensions is stable within a project (e.g., a Rust project always targets `.rs`). Making it a config value avoids repeating `--ext` on every command invocation. The setting is optional and defaults to scanning all text files, ensuring zero friction for new users and full backward compatibility for existing projects.
 
+Beyond the binary-file check, some text files are clearly not source code. Dot files (`.keep`, `.gitignore`, `.env`, `.editorconfig`, etc.) are universally configuration or metadata — no project would place `@specre` markers in them. SVG files are XML-encoded vector graphics that pass UTF-8 decoding but are image assets. The scanner excludes both categories unconditionally, keeping the built-in exclusion list minimal and unambiguous.
+
 ## Key Members
 
 - `Config.target_extensions: Option<Vec<String>>` — list of extensions (without leading dots) read from `specre.toml`. `None` means scan all files.
 - `InitArgs.ext: Option<Vec<String>>` — CLI argument `--ext` for `specre init` (comma-separated, e.g., `--ext rs,ts,js`).
+- `EXCLUDED_EXTENSIONS: &[&str]` — built-in list of extensions always excluded from scanning (currently: `["svg"]`).
 
 ## Scenarios
 
@@ -37,7 +42,7 @@ This setting is project-level because the set of relevant source extensions is s
 2. `specre.toml` is created without a `target_extensions` field
 3. User runs `specre index`
 4. CLI reads `specre.toml`, finds no `target_extensions` field
-5. CLI scans all text files in `source_dirs` for `@specre` markers; binary (non-UTF-8) files are skipped silently
+5. CLI scans all text files in `source_dirs` for `@specre` markers; binary (non-UTF-8) files, dot files, and SVG files are skipped silently
 
 ### Init with target extensions
 
@@ -54,7 +59,7 @@ This setting is project-level because the set of relevant source extensions is s
 2. User updates specre binary to the new version
 3. User runs `specre index`
 4. CLI reads `specre.toml`, `target_extensions` field is missing
-5. All text files in `source_dirs` are scanned; binary files are skipped silently
+5. All text files in `source_dirs` are scanned; binary files, dot files, and SVG files are skipped silently
 
 ### Extensions are specified without leading dots
 
@@ -90,6 +95,22 @@ This setting is project-level because the set of relevant source extensions is s
 2. User runs `specre index`
 3. No source files are scanned (empty filter matches nothing)
 4. `source_refs` array in `index.json` is empty
+
+### Dot files are always excluded
+
+1. A project has `source_dirs = ["src"]` without `target_extensions`
+2. `src/` contains `.keep`, `.gitignore`, and `main.rs`
+3. User runs `specre coverage`
+4. Only `main.rs` is counted as a source file; `.keep` and `.gitignore` are excluded
+5. This also applies when `target_extensions` is set — dot files are never scanned
+
+### SVG files are always excluded
+
+1. A project has `source_dirs = ["src"]` without `target_extensions`
+2. `src/` contains `icon.svg` and `main.rs`
+3. User runs `specre coverage`
+4. Only `main.rs` is counted as a source file; `icon.svg` is excluded despite being valid UTF-8 text
+5. This also applies when `target_extensions` is set — SVG files are never scanned
 
 ## Failures / Exceptions
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,799 +1,799 @@
 {
-  "generated_at": "2026-02-22T08:10:37Z",
-  "source_refs": [
-    {
-      "file": "src/card.rs",
-      "line": 1,
-      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z"
-    },
-    {
-      "file": "src/card.rs",
-      "line": 2,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "src/card.rs",
-      "line": 3,
-      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49"
-    },
-    {
-      "file": "src/card.rs",
-      "line": 4,
-      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1"
-    },
-    {
-      "file": "src/cli.rs",
-      "line": 1,
-      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
-    },
-    {
-      "file": "src/commands/coverage.rs",
-      "line": 1,
-      "specre_id": "01KHFEA9QVV4A127VCRJY97A68"
-    },
-    {
-      "file": "src/commands/coverage.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/health_check.rs",
-      "line": 1,
-      "specre_id": "01KHFGVXWP100JXYBZTRJGMB9H"
-    },
-    {
-      "file": "src/commands/index.rs",
-      "line": 1,
-      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE"
-    },
-    {
-      "file": "src/commands/index.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/init.rs",
-      "line": 1,
-      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N"
-    },
-    {
-      "file": "src/commands/init.rs",
-      "line": 2,
-      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9"
-    },
-    {
-      "file": "src/commands/init.rs",
-      "line": 3,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 1,
-      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 2,
-      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 3,
-      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 4,
-      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 5,
-      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 6,
-      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 7,
-      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM"
-    },
-    {
-      "file": "src/commands/mcp/helpers.rs",
-      "line": 8,
-      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE"
-    },
-    {
-      "file": "src/commands/mcp/mod.rs",
-      "line": 1,
-      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1"
-    },
-    {
-      "file": "src/commands/mcp/mod.rs",
-      "line": 2,
-      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE"
-    },
-    {
-      "file": "src/commands/mcp/search.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 1,
-      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 2,
-      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 3,
-      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 4,
-      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 5,
-      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 6,
-      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 7,
-      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 8,
-      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM"
-    },
-    {
-      "file": "src/commands/mcp/tools.rs",
-      "line": 9,
-      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE"
-    },
-    {
-      "file": "src/commands/mod.rs",
-      "line": 1,
-      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
-    },
-    {
-      "file": "src/commands/new.rs",
-      "line": 1,
-      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z"
-    },
-    {
-      "file": "src/commands/new.rs",
-      "line": 2,
-      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC"
-    },
-    {
-      "file": "src/commands/new.rs",
-      "line": 3,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/orphans.rs",
-      "line": 1,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "src/commands/orphans.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/search/hint.rs",
-      "line": 1,
-      "specre_id": "01KHQBKWZY2D77XP7A50HGTZQ8"
-    },
-    {
-      "file": "src/commands/search/mod.rs",
-      "line": 1,
-      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49"
-    },
-    {
-      "file": "src/commands/status.rs",
-      "line": 1,
-      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ"
-    },
-    {
-      "file": "src/commands/status.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/tag.rs",
-      "line": 1,
-      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z"
-    },
-    {
-      "file": "src/commands/tag.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/commands/trace.rs",
-      "line": 1,
-      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ"
-    },
-    {
-      "file": "src/commands/trace.rs",
-      "line": 2,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 1,
-      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 2,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 3,
-      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 4,
-      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 5,
-      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 6,
-      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 7,
-      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC"
-    },
-    {
-      "file": "src/config.rs",
-      "line": 8,
-      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9"
-    },
-    {
-      "file": "src/error.rs",
-      "line": 1,
-      "specre_id": "01KHMEB8WF7BFZASE8SQHF5PR2"
-    },
-    {
-      "file": "src/main.rs",
-      "line": 1,
-      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
-    },
-    {
-      "file": "src/parser.rs",
-      "line": 1,
-      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ"
-    },
-    {
-      "file": "src/scanner.rs",
-      "line": 1,
-      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z"
-    },
-    {
-      "file": "src/scanner.rs",
-      "line": 2,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "src/scanner.rs",
-      "line": 3,
-      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9"
-    },
-    {
-      "file": "src/status.rs",
-      "line": 1,
-      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE"
-    },
-    {
-      "file": "src/status.rs",
-      "line": 2,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "src/status.rs",
-      "line": 3,
-      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49"
-    },
-    {
-      "file": "src/status.rs",
-      "line": 4,
-      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ"
-    },
-    {
-      "file": "src/template.rs",
-      "line": 1,
-      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z"
-    },
-    {
-      "file": "src/template.rs",
-      "line": 2,
-      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC"
-    },
-    {
-      "file": "src/ulid.rs",
-      "line": 1,
-      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z"
-    },
-    {
-      "file": "tests/cli_coverage.rs",
-      "line": 1,
-      "specre_id": "01KHFEA9QVV4A127VCRJY97A68"
-    },
-    {
-      "file": "tests/cli_dispatch.rs",
-      "line": 1,
-      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
-    },
-    {
-      "file": "tests/cli_health_check.rs",
-      "line": 1,
-      "specre_id": "01KHFGVXWP100JXYBZTRJGMB9H"
-    },
-    {
-      "file": "tests/cli_index.rs",
-      "line": 1,
-      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE"
-    },
-    {
-      "file": "tests/cli_init.rs",
-      "line": 1,
-      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N"
-    },
-    {
-      "file": "tests/cli_json_output.rs",
-      "line": 1,
-      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8"
-    },
-    {
-      "file": "tests/cli_new.rs",
-      "line": 1,
-      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z"
-    },
-    {
-      "file": "tests/cli_orphans.rs",
-      "line": 1,
-      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT"
-    },
-    {
-      "file": "tests/cli_search.rs",
-      "line": 1,
-      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49"
-    },
-    {
-      "file": "tests/cli_search.rs",
-      "line": 2,
-      "specre_id": "01KHQBKWZY2D77XP7A50HGTZQ8"
-    },
-    {
-      "file": "tests/cli_status.rs",
-      "line": 1,
-      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ"
-    },
-    {
-      "file": "tests/cli_tag.rs",
-      "line": 1,
-      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z"
-    },
-    {
-      "file": "tests/cli_trace.rs",
-      "line": 1,
-      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ"
-    },
-    {
-      "file": "tests/common/mod.rs",
-      "line": 1,
-      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 1,
-      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 2,
-      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 3,
-      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 4,
-      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 5,
-      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 6,
-      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 7,
-      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 8,
-      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 9,
-      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 10,
-      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM"
-    },
-    {
-      "file": "tests/mcp/helpers.rs",
-      "line": 11,
-      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 1,
-      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 2,
-      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 3,
-      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 4,
-      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 5,
-      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 6,
-      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 7,
-      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 8,
-      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 9,
-      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 10,
-      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM"
-    },
-    {
-      "file": "tests/mcp/main.rs",
-      "line": 11,
-      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE"
-    },
-    {
-      "file": "tests/mcp/resources.rs",
-      "line": 1,
-      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE"
-    },
-    {
-      "file": "tests/mcp/server.rs",
-      "line": 1,
-      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1"
-    },
-    {
-      "file": "tests/mcp/tool_coverage.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM"
-    },
-    {
-      "file": "tests/mcp/tool_health_check.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE"
-    },
-    {
-      "file": "tests/mcp/tool_index.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W"
-    },
-    {
-      "file": "tests/mcp/tool_new.rs",
-      "line": 1,
-      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN"
-    },
-    {
-      "file": "tests/mcp/tool_orphans.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z"
-    },
-    {
-      "file": "tests/mcp/tool_search.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN"
-    },
-    {
-      "file": "tests/mcp/tool_status.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9"
-    },
-    {
-      "file": "tests/mcp/tool_tag.rs",
-      "line": 1,
-      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H"
-    },
-    {
-      "file": "tests/mcp/tool_trace.rs",
-      "line": 1,
-      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM"
-    }
-  ],
+  "version": 1,
+  "generated_at": "2026-02-22T08:46:16Z",
   "specres": [
     {
-      "domain": "cli",
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
-      "last_verified": "2026-02-16",
       "name": "specre_new_scaffolds_a_new_specre",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_new_scaffolds_a_new_specre.md",
-      "status": "stable"
+      "last_verified": "2026-02-16"
     },
     {
-      "domain": "cli",
       "id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
-      "last_verified": "2026-02-18",
       "name": "specre_init_initializes_project_configuration",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_init_initializes_project_configuration.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "cli",
       "id": "01KHAKAYN5WPTDVR99D5Q5TMJE",
-      "last_verified": "2026-02-18",
       "name": "specre_index_generates_project_index",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_index_generates_project_index.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "cli",
       "id": "01KHAN6JE712ZAKXPP97854PKJ",
-      "last_verified": "2026-02-17",
       "name": "specre_status_reports_project_health",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_status_reports_project_health.md",
-      "status": "stable"
+      "last_verified": "2026-02-17"
     },
     {
-      "domain": "cli",
       "id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
-      "last_verified": "2026-02-17",
       "name": "specre_trace_resolves_bidirectional_references",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_trace_resolves_bidirectional_references.md",
-      "status": "stable"
+      "last_verified": "2026-02-17"
     },
     {
-      "domain": "cli",
       "id": "01KHB48EES4FR5TFV6ZP2W3MGT",
-      "last_verified": "2026-02-22",
       "name": "specre_orphans_detects_unlinked_specres_and_markers",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_orphans_detects_unlinked_specres_and_markers.md",
-      "status": "stable"
+      "last_verified": "2026-02-22"
     },
     {
-      "domain": "cli",
       "id": "01KHB48EYB9686YYQMYFYQ5R1Z",
-      "last_verified": "2026-02-17",
       "name": "specre_tag_inserts_marker_into_source_file",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_tag_inserts_marker_into_source_file.md",
-      "status": "stable"
+      "last_verified": "2026-02-17"
     },
     {
-      "domain": "cli",
       "id": "01KHDF9WHR5HFM4RQCF6HS3KCC",
-      "last_verified": "2026-02-14",
       "name": "user_can_set_language_config",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/user_can_set_language_config.md",
-      "status": "stable"
+      "last_verified": "2026-02-14"
     },
     {
-      "domain": "cli",
       "id": "01KHFD5R1G3C5R34XMQXQTTMM9",
-      "last_verified": "2026-02-22",
       "name": "user_can_set_target_extensions",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/user_can_set_target_extensions.md",
-      "status": "stable"
+      "last_verified": "2026-02-22"
     },
     {
-      "domain": "cli",
       "id": "01KHFEA9QVV4A127VCRJY97A68",
-      "last_verified": "2026-02-22",
       "name": "specre_coverage_reports_source_file_tagging",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_coverage_reports_source_file_tagging.md",
-      "status": "stable"
+      "last_verified": "2026-02-22"
     },
     {
-      "domain": "cli",
       "id": "01KHFFCX8BCDAYP8YHG0J65H0E",
-      "last_verified": "2026-02-15",
       "name": "specre_cli_dispatches_commands_and_handles_errors",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_cli_dispatches_commands_and_handles_errors.md",
-      "status": "stable"
+      "last_verified": "2026-02-15"
     },
     {
-      "domain": "cli",
       "id": "01KHFGVXWP100JXYBZTRJGMB9H",
-      "last_verified": "2026-02-18",
       "name": "specre_health_check_verifies_ecosystem_trustworthiness",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_health_check_verifies_ecosystem_trustworthiness.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "cli",
       "id": "01KHFTCYJN8YJMW2RNHJTAQV49",
-      "last_verified": "2026-02-18",
       "name": "specre_search_finds_specre_cards_by_query",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_search_finds_specre_cards_by_query.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "cli",
       "id": "01KHG0A2V4YXE918WMJCY7WFE8",
-      "last_verified": "2026-02-17",
       "name": "specre_commands_support_json_output",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_commands_support_json_output.md",
-      "status": "stable"
+      "last_verified": "2026-02-17"
     },
     {
-      "domain": "mcp",
       "id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
-      "last_verified": "2026-02-17",
       "name": "mcp_server_starts_via_stdio",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_server_starts_via_stdio.md",
-      "status": "stable"
+      "last_verified": "2026-02-17"
     },
     {
-      "domain": "mcp",
       "id": "01KHJ98TFCDTCARMMX1GC5ZHXE",
-      "last_verified": "2026-02-16",
       "name": "mcp_resources_expose_specre_cards",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_resources_expose_specre_cards.md",
-      "status": "stable"
+      "last_verified": "2026-02-16"
     },
     {
-      "domain": "mcp",
       "id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_new_creates_specre_card",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_new_creates_specre_card.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "cli",
       "id": "01KHMEB8WF7BFZASE8SQHF5PR2",
-      "last_verified": "2026-02-17",
       "name": "specre_error_provides_contextual_diagnostics",
-      "path": "docs/specres/cli/specre_error_provides_contextual_diagnostics.md",
-      "status": "stable"
-    },
-    {
+      "status": "stable",
       "domain": "cli",
+      "path": "docs/specres/cli/specre_error_provides_contextual_diagnostics.md",
+      "last_verified": "2026-02-17"
+    },
+    {
       "id": "01KHQBKWZY2D77XP7A50HGTZQ8",
-      "last_verified": "2026-02-18",
       "name": "specre_search_hints_guide_query_refinement",
+      "status": "stable",
+      "domain": "cli",
       "path": "docs/specres/cli/specre_search_hints_guide_query_refinement.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQJG96BS5STGSENPNDHEH1H",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_tag_inserts_marker_into_source_file",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_tag_inserts_marker_into_source_file.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ5M6N304YYJNW8VDKT4W",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_index_regenerates_index",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_index_regenerates_index.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_status_reports_project_health",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_status_reports_project_health.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ633JHVDK0WADPPVP3CM",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_trace_looks_up_traceability",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_trace_looks_up_traceability.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_orphans_detects_unlinked_specres",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_orphans_detects_unlinked_specres.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ6H8FB46ESFXB03N85AN",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_search_queries_specre_cards",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_search_queries_specre_cards.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_coverage_reports_tag_coverage",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_coverage_reports_tag_coverage.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     },
     {
-      "domain": "mcp",
       "id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
-      "last_verified": "2026-02-18",
       "name": "mcp_tool_health_check_runs_preflight",
+      "status": "stable",
+      "domain": "mcp",
       "path": "docs/specres/mcp/mcp_tool_health_check_runs_preflight.md",
-      "status": "stable"
+      "last_verified": "2026-02-18"
     }
   ],
-  "version": 1
+  "source_refs": [
+    {
+      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
+      "file": "src/card.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "src/card.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49",
+      "file": "src/card.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
+      "file": "src/card.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/cli.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
+      "file": "src/commands/coverage.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/coverage.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHFGVXWP100JXYBZTRJGMB9H",
+      "file": "src/commands/health_check.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE",
+      "file": "src/commands/index.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/index.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
+      "file": "src/commands/init.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9",
+      "file": "src/commands/init.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/init.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 5
+    },
+    {
+      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 6
+    },
+    {
+      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 7
+    },
+    {
+      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
+      "file": "src/commands/mcp/helpers.rs",
+      "line": 8
+    },
+    {
+      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
+      "file": "src/commands/mcp/mod.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE",
+      "file": "src/commands/mcp/mod.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN",
+      "file": "src/commands/mcp/search.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 5
+    },
+    {
+      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 6
+    },
+    {
+      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 7
+    },
+    {
+      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 8
+    },
+    {
+      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
+      "file": "src/commands/mcp/tools.rs",
+      "line": 9
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/commands/mod.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
+      "file": "src/commands/new.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC",
+      "file": "src/commands/new.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/new.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "src/commands/orphans.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/orphans.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHQBKWZY2D77XP7A50HGTZQ8",
+      "file": "src/commands/search/hint.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49",
+      "file": "src/commands/search/mod.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ",
+      "file": "src/commands/status.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/status.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
+      "file": "src/commands/tag.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/tag.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
+      "file": "src/commands/trace.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "src/commands/trace.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
+      "file": "src/config.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "src/config.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
+      "file": "src/config.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ",
+      "file": "src/config.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE",
+      "file": "src/config.rs",
+      "line": 5
+    },
+    {
+      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
+      "file": "src/config.rs",
+      "line": 6
+    },
+    {
+      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC",
+      "file": "src/config.rs",
+      "line": 7
+    },
+    {
+      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9",
+      "file": "src/config.rs",
+      "line": 8
+    },
+    {
+      "specre_id": "01KHMEB8WF7BFZASE8SQHF5PR2",
+      "file": "src/error.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "src/main.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
+      "file": "src/parser.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
+      "file": "src/scanner.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "src/scanner.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHFD5R1G3C5R34XMQXQTTMM9",
+      "file": "src/scanner.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE",
+      "file": "src/status.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "src/status.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49",
+      "file": "src/status.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ",
+      "file": "src/status.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
+      "file": "src/template.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHDF9WHR5HFM4RQCF6HS3KCC",
+      "file": "src/template.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
+      "file": "src/ulid.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFEA9QVV4A127VCRJY97A68",
+      "file": "tests/cli_coverage.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "tests/cli_dispatch.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFGVXWP100JXYBZTRJGMB9H",
+      "file": "tests/cli_health_check.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHAKAYN5WPTDVR99D5Q5TMJE",
+      "file": "tests/cli_index.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHAGG8NQQ7RSNYZ6SWBCYH3N",
+      "file": "tests/cli_init.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHG0A2V4YXE918WMJCY7WFE8",
+      "file": "tests/cli_json_output.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
+      "file": "tests/cli_new.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EES4FR5TFV6ZP2W3MGT",
+      "file": "tests/cli_orphans.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFTCYJN8YJMW2RNHJTAQV49",
+      "file": "tests/cli_search.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQBKWZY2D77XP7A50HGTZQ8",
+      "file": "tests/cli_search.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHAN6JE712ZAKXPP97854PKJ",
+      "file": "tests/cli_status.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48EYB9686YYQMYFYQ5R1Z",
+      "file": "tests/cli_tag.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHB48DYZDN8GHXPX7MSYJ1NZ",
+      "file": "tests/cli_trace.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHFFCX8BCDAYP8YHG0J65H0E",
+      "file": "tests/common/mod.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
+      "file": "tests/mcp/helpers.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE",
+      "file": "tests/mcp/helpers.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
+      "file": "tests/mcp/helpers.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H",
+      "file": "tests/mcp/helpers.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W",
+      "file": "tests/mcp/helpers.rs",
+      "line": 5
+    },
+    {
+      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
+      "file": "tests/mcp/helpers.rs",
+      "line": 6
+    },
+    {
+      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM",
+      "file": "tests/mcp/helpers.rs",
+      "line": 7
+    },
+    {
+      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
+      "file": "tests/mcp/helpers.rs",
+      "line": 8
+    },
+    {
+      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN",
+      "file": "tests/mcp/helpers.rs",
+      "line": 9
+    },
+    {
+      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
+      "file": "tests/mcp/helpers.rs",
+      "line": 10
+    },
+    {
+      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
+      "file": "tests/mcp/helpers.rs",
+      "line": 11
+    },
+    {
+      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
+      "file": "tests/mcp/main.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE",
+      "file": "tests/mcp/main.rs",
+      "line": 2
+    },
+    {
+      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
+      "file": "tests/mcp/main.rs",
+      "line": 3
+    },
+    {
+      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H",
+      "file": "tests/mcp/main.rs",
+      "line": 4
+    },
+    {
+      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W",
+      "file": "tests/mcp/main.rs",
+      "line": 5
+    },
+    {
+      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
+      "file": "tests/mcp/main.rs",
+      "line": 6
+    },
+    {
+      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM",
+      "file": "tests/mcp/main.rs",
+      "line": 7
+    },
+    {
+      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
+      "file": "tests/mcp/main.rs",
+      "line": 8
+    },
+    {
+      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN",
+      "file": "tests/mcp/main.rs",
+      "line": 9
+    },
+    {
+      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
+      "file": "tests/mcp/main.rs",
+      "line": 10
+    },
+    {
+      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
+      "file": "tests/mcp/main.rs",
+      "line": 11
+    },
+    {
+      "specre_id": "01KHJ98TFCDTCARMMX1GC5ZHXE",
+      "file": "tests/mcp/resources.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHJ98T83DPJGMEFH9HAXXAZ1",
+      "file": "tests/mcp/server.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ6RE7Z3WEDZ54ZKHM6BM",
+      "file": "tests/mcp/tool_coverage.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ6ZHSZX3GR2D7DS23XTE",
+      "file": "tests/mcp/tool_health_check.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ5M6N304YYJNW8VDKT4W",
+      "file": "tests/mcp/tool_index.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHK7MFZJZ12XFPQE4RHCBHQN",
+      "file": "tests/mcp/tool_new.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ6AAMY6Y6AQB3VDVSF6Z",
+      "file": "tests/mcp/tool_orphans.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ6H8FB46ESFXB03N85AN",
+      "file": "tests/mcp/tool_search.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ5VKTHSD483ZWK0RYPR9",
+      "file": "tests/mcp/tool_status.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQJG96BS5STGSENPNDHEH1H",
+      "file": "tests/mcp/tool_tag.rs",
+      "line": 1
+    },
+    {
+      "specre_id": "01KHQKZ633JHVDK0WADPPVP3CM",
+      "file": "tests/mcp/tool_trace.rs",
+      "line": 1
+    }
+  ]
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -48,6 +48,10 @@ pub fn collect_md_files<F: FnMut(&Path)>(dir: &Path, cb: &mut F) {
     }
 }
 
+/// Extensions that are always excluded from source scanning.
+/// These are text files that pass UTF-8 decoding but are never source code.
+const EXCLUDED_EXTENSIONS: &[&str] = &["svg"];
+
 pub fn collect_all_files<F: FnMut(&Path)>(
     dir: &Path,
     target_extensions: Option<&[String]>,
@@ -83,15 +87,30 @@ pub fn collect_all_files<F: FnMut(&Path)>(
                 continue;
             }
             collect_all_files(&path, target_extensions, cb);
-        } else if let Some(exts) = target_extensions {
-            let matches = path
-                .extension()
-                .is_some_and(|ext| exts.iter().any(|e| e == ext.to_string_lossy().as_ref()));
-            if !matches {
+        } else {
+            // Skip dot files (mirrors dot-directory exclusion above)
+            if path
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy().starts_with('.'))
+            {
                 continue;
             }
-            cb(&path);
-        } else {
+            // Skip built-in excluded extensions
+            if path.extension().is_some_and(|ext| {
+                EXCLUDED_EXTENSIONS
+                    .iter()
+                    .any(|e| *e == ext.to_string_lossy().as_ref())
+            }) {
+                continue;
+            }
+            if let Some(exts) = target_extensions {
+                let matches = path
+                    .extension()
+                    .is_some_and(|ext| exts.iter().any(|e| e == ext.to_string_lossy().as_ref()));
+                if !matches {
+                    continue;
+                }
+            }
             cb(&path);
         }
     }

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -453,3 +453,73 @@ fn coverage_warns_on_unreadable_source_file() {
 
     fs::set_permissions(&bad_file, fs::Permissions::from_mode(0o644)).unwrap();
 }
+
+// -- Scenario: Dot files are always excluded --
+
+#[test]
+fn coverage_excludes_dot_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // Dot files — should be excluded
+    write_source(tmp.path(), "src/.keep", "");
+    write_source(tmp.path(), "src/.gitignore", "*.tmp\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+#[test]
+fn coverage_excludes_dot_files_even_with_target_extensions() {
+    let tmp = TempDir::new().unwrap();
+    // .keep has no extension so it wouldn't match anyway,
+    // but .gitignore-like files with matching extensions should still be excluded
+    write_config_with_ext(tmp.path(), "docs/specres", &["src"], &["rs"]);
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    write_source(tmp.path(), "src/.hidden.rs", "fn hidden() {}\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: SVG files are always excluded --
+
+#[test]
+fn coverage_excludes_svg_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // SVG file — valid UTF-8 but should be excluded
+    write_source(
+        tmp.path(),
+        "src/icon.svg",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle r=\"10\"/></svg>\n",
+    );
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -658,6 +658,86 @@ fn index_without_target_extensions_scans_all_files() {
     assert_eq!(refs.len(), 2);
 }
 
+// -- Scenario: Dot files are always excluded from source scanning --
+
+#[test]
+fn index_excludes_dot_files_from_source_scan() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/my_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "my_spec",
+        "draft",
+        None,
+    );
+    // Normal source file with marker
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // Dot files — should be excluded even though they're valid text
+    write_source(tmp.path(), "src/.keep", "");
+    write_source(tmp.path(), "src/.gitignore", "*.tmp\n");
+
+    specre()
+        .args(["index"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    let refs = json["source_refs"].as_array().unwrap();
+    // Only main.rs should be scanned; dot files excluded
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0]["file"], "src/main.rs");
+}
+
+// -- Scenario: SVG files are always excluded from source scanning --
+
+#[test]
+fn index_excludes_svg_files_from_source_scan() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/my_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "my_spec",
+        "draft",
+        None,
+    );
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // SVG file — valid UTF-8 text but should be excluded
+    write_source(
+        tmp.path(),
+        "src/icon.svg",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\"><circle r=\"10\"/></svg>\n",
+    );
+
+    specre()
+        .args(["index"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    let refs = json["source_refs"].as_array().unwrap();
+    // Only main.rs should be scanned; SVG excluded
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0]["file"], "src/main.rs");
+}
+
 // -- Failures / Exceptions: IO errors print warning and skip --
 
 #[test]


### PR DESCRIPTION
## Summary

- Dot files (`.keep`, `.gitignore`, `.env`, etc.) and `.svg` files are now unconditionally excluded from source scanning
- Dot files are universally configuration/metadata; SVG files are image assets that pass UTF-8 but are not source code
- Built-in exclusions apply regardless of `target_extensions` setting, matching the existing dot-directory exclusion behavior

## Changes

- `src/scanner.rs`: Added `EXCLUDED_EXTENSIONS` constant and dot-file/SVG exclusion logic in `collect_all_files`
- `docs/specres/cli/user_can_set_target_extensions.md`: Updated specre card with new scenarios and design intent
- `tests/cli_coverage.rs`: Added 3 tests (dot files, dot files with target_extensions, SVG files)
- `tests/cli_index.rs`: Added 2 tests (dot files, SVG files in index)

## Test plan

- [x] New tests for dot file exclusion (coverage and index)
- [x] New tests for SVG file exclusion (coverage and index)
- [x] New test for dot file exclusion with `target_extensions` set
- [x] All existing tests pass (no regressions)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)