### PR TITLE
fix: use content comparison for index freshness in health-check

### DIFF
--- a/docs/specres/cli/_INDEX.md
+++ b/docs/specres/cli/_INDEX.md
@@ -13,7 +13,7 @@
 | [user_can_set_target_extensions](user_can_set_target_extensions.md) | stable | 2026-02-22 |
 | [specre_coverage_reports_source_file_tagging](specre_coverage_reports_source_file_tagging.md) | stable | 2026-02-22 |
 | [specre_cli_dispatches_commands_and_handles_errors](specre_cli_dispatches_commands_and_handles_errors.md) | stable | 2026-02-15 |
-| [specre_health_check_verifies_ecosystem_trustworthiness](specre_health_check_verifies_ecosystem_trustworthiness.md) | stable | 2026-02-18 |
+| [specre_health_check_verifies_ecosystem_trustworthiness](specre_health_check_verifies_ecosystem_trustworthiness.md) | stable | 2026-02-22 |
 | [specre_search_finds_specre_cards_by_query](specre_search_finds_specre_cards_by_query.md) | stable | 2026-02-18 |
 | [specre_commands_support_json_output](specre_commands_support_json_output.md) | stable | 2026-02-17 |
 | [specre_error_provides_contextual_diagnostics](specre_error_provides_contextual_diagnostics.md) | stable | 2026-02-17 |

--- a/docs/specres/cli/specre_health_check_verifies_ecosystem_trustworthiness.md
+++ b/docs/specres/cli/specre_health_check_verifies_ecosystem_trustworthiness.md
@@ -2,12 +2,13 @@
 id: "01KHFGVXWP100JXYBZTRJGMB9H"
 name: "specre_health_check_verifies_ecosystem_trustworthiness"
 status: "stable"
-last_verified: "2026-02-18"
+last_verified: "2026-02-22"
 ---
 
 ## Related Files
 
 - `src/commands/health_check.rs`
+- `src/commands/index.rs` (reuses index generation logic for content comparison)
 - `src/scanner.rs` (reuses `scan_source_markers()`)
 - `src/commands/coverage.rs` (reuses `coverage_from_scan_ref()`)
 - `src/commands/orphans.rs` (reuses `orphans_from_scan_ref()`)
@@ -21,6 +22,8 @@ last_verified: "2026-02-18"
 
 `specre health-check` is a single entry point for coding agents to verify that the specre ecosystem is trustworthy before starting a task. It aggregates three metrics — coverage ratio, orphan count, and index freshness — into one structured JSON response, enabling agents to unambiguously determine whether specre cards can be relied upon without interpreting multiple commands individually. Each metric is compared against configurable thresholds (with sensible defaults), and a top-level `healthy` boolean summarizes whether all metrics are within acceptable bounds.
 
+Index freshness uses a two-stage evaluation: first, the `generated_at` timestamp is checked against the `index_age_hours` threshold. If the timestamp is within the threshold, the index is considered fresh. If the timestamp exceeds the threshold, health-check performs a **content comparison** — it regenerates the index data in memory (without writing to disk) and compares the `specres` and `source_refs` arrays against the existing `index.json`. If the content is identical, the index is still considered fresh (the timestamp is old but the data is accurate). Only when the content actually differs is the index considered stale.
+
 ## Design Intent
 
 AI agents need a fast, unambiguous signal before trusting specre cards as a source of truth for a coding session. Rather than requiring agents to run `coverage`, `orphans`, and check `index.json` separately — and then interpret the combined results — `health-check` provides a single JSON object with a clear `healthy` verdict. This makes it ideal as the first command an agent runs at the start of a session, or as an MCP server query.
@@ -29,7 +32,8 @@ AI agents need a fast, unambiguous signal before trusting specre cards as a sour
 
 - `HealthCheckResult` — struct containing `healthy: bool`, `coverage: f64`, `orphans: usize`, `index_age_hours: f64`, and `thresholds: Thresholds`
 - `Thresholds` — struct with `coverage: f64` (default `0.90`), `orphans: usize` (default `5`), `index_age_hours: f64` (default `24.0`); configurable via `specre.toml` under `[health_check]` section
-- `healthy` — `true` when `coverage >= thresholds.coverage` AND `orphans <= thresholds.orphans` AND `index_age_hours <= thresholds.index_age_hours`
+- `healthy` — `true` when `coverage >= thresholds.coverage` AND `orphans <= thresholds.orphans` AND index is fresh (see below)
+- Index freshness — the index is fresh when `index_age_hours <= thresholds.index_age_hours`, OR when the timestamp exceeds the threshold but a content comparison confirms that `specres` and `source_refs` in the existing `index.json` are identical to what would be regenerated. If `index.json` does not exist or cannot be parsed, the index is always stale
 - `coverage` — ratio (0.0–1.0) of source files containing at least one `@specre` marker, computed via `compute_coverage()`
 - `orphans` — total count of orphan specres (non-deprecated specres with no source markers) plus dangling markers (markers with no matching specre), computed via `compute_orphans()`
 - `index_age_hours` — hours since `index.json` was last generated, derived from its `generated_at` field. If `index.json` does not exist, this is reported as `null` and the metric is treated as failing (unhealthy)
@@ -70,11 +74,21 @@ AI agents need a fast, unambiguous signal before trusting specre cards as a sour
 2. CLI outputs JSON with `"healthy": false` and `"index_age_hours": null`
 3. CLI exits with exit code 1
 
-### Unhealthy ecosystem — index.json stale
+### Unhealthy ecosystem — index.json stale with content drift
 
 1. User runs `specre health-check` where `index.json` was generated more than 24 hours ago
-2. CLI outputs JSON with `"healthy": false` and `"index_age_hours"` reflecting the actual age
-3. CLI exits with exit code 1
+2. Since the timestamp exceeds the threshold, health-check regenerates index data in memory and compares it against the existing `index.json`
+3. The content differs (e.g., new specre cards were added, source files gained or lost `@specre` markers)
+4. CLI outputs JSON with `"healthy": false` and `"index_age_hours"` reflecting the actual age
+5. CLI exits with exit code 1
+
+### Stale timestamp but content identical — treated as healthy
+
+1. User runs `specre health-check` where `index.json` was generated more than 24 hours ago but no specre cards or source `@specre` markers have changed since then
+2. Since the timestamp exceeds the threshold, health-check regenerates index data in memory and compares it against the existing `index.json`
+3. The `specres` and `source_refs` arrays are identical — only `generated_at` differs
+4. CLI outputs JSON with `"healthy": true` and `"index_age_hours"` reflecting the actual (old) age
+5. CLI exits with exit code 0
 
 ### Custom thresholds via specre.toml
 

--- a/docs/specres/index.json
+++ b/docs/specres/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-02-22T08:46:16Z",
+  "generated_at": "2026-02-22T09:04:21Z",
   "specres": [
     {
       "id": "01JMBJK7QRVX3N4P5G6H8W9Y0Z",
@@ -96,7 +96,7 @@
       "status": "stable",
       "domain": "cli",
       "path": "docs/specres/cli/specre_health_check_verifies_ecosystem_trustworthiness.md",
-      "last_verified": "2026-02-18"
+      "last_verified": "2026-02-22"
     },
     {
       "id": "01KHFTCYJN8YJMW2RNHJTAQV49",

--- a/src/commands/health_check.rs
+++ b/src/commands/health_check.rs
@@ -1,12 +1,14 @@
 // @specre 01KHFGVXWP100JXYBZTRJGMB9H
+use crate::card;
 use crate::commands::coverage::coverage_from_scan_ref;
 use crate::commands::orphans::orphans_from_scan_ref;
 use crate::config;
 use crate::error::SpecreError;
-use crate::scanner::scan_source_markers;
+use crate::scanner::{SourceScanResult, scan_source_markers};
 use chrono::Utc;
 use serde::Serialize;
 use std::fs;
+use std::path::Path;
 
 #[derive(Serialize)]
 struct HealthCheckResult {
@@ -24,8 +26,13 @@ struct Thresholds {
     index_age_hours: f64,
 }
 
-fn get_index_age_hours(specre_dir: &str) -> Option<f64> {
-    let index_path = std::path::Path::new(specre_dir).join("index.json");
+struct IndexInfo {
+    age_hours: f64,
+    json: serde_json::Value,
+}
+
+fn load_index(specre_dir: &str) -> Option<IndexInfo> {
+    let index_path = Path::new(specre_dir).join("index.json");
     let content = match fs::read_to_string(&index_path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
@@ -54,8 +61,45 @@ fn get_index_age_hours(specre_dir: &str) -> Option<f64> {
     };
     let age = Utc::now().signed_duration_since(generated);
     let hours = age.num_minutes() as f64 / 60.0;
-    // Round to one decimal place
-    Some((hours * 10.0).round() / 10.0)
+    let age_hours = (hours * 10.0).round() / 10.0;
+    Some(IndexInfo {
+        age_hours,
+        json: parsed,
+    })
+}
+
+/// Checks whether the existing `index.json` content matches what would be
+/// regenerated from the current specre cards and source markers.
+fn is_index_content_current(
+    cfg: &config::Config,
+    scan: &SourceScanResult,
+    existing_json: &serde_json::Value,
+) -> bool {
+    // Build fresh specre cards
+    let specre_dir = Path::new(&cfg.specre_dir);
+    let fresh_specres = card::scan_specre_cards(specre_dir, &cfg.specre_dir);
+
+    let Ok(fresh_specres_value) = serde_json::to_value(&fresh_specres) else {
+        return false;
+    };
+
+    // Build fresh source_refs from scan results (same shape as index.rs SourceRef)
+    let fresh_source_refs: Vec<serde_json::Value> = scan
+        .all_markers
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "specre_id": m.ulid,
+                "file": m.file,
+                "line": m.line,
+            })
+        })
+        .collect();
+    let fresh_source_refs_value = serde_json::Value::Array(fresh_source_refs);
+
+    // Compare with existing index content
+    existing_json.get("specres") == Some(&fresh_specres_value)
+        && existing_json.get("source_refs") == Some(&fresh_source_refs_value)
 }
 
 /// # Errors
@@ -86,13 +130,18 @@ pub fn execute() -> Result<(), SpecreError> {
     let orphan_result = orphans_from_scan_ref(&cfg.specre_dir, &scan);
     let orphan_count = orphan_result.orphan_count() + orphan_result.dangling_count();
 
-    // Index freshness
-    let index_age_hours = get_index_age_hours(&cfg.specre_dir);
+    // Index freshness (two-stage: timestamp check, then content comparison)
+    let index_info = load_index(&cfg.specre_dir);
+    let index_age_hours = index_info.as_ref().map(|i| i.age_hours);
 
     // Healthy check
     let coverage_ok = coverage_ratio >= threshold_coverage;
     let orphans_ok = orphan_count <= threshold_orphans;
-    let index_ok = index_age_hours.is_some_and(|age| age <= threshold_index_age);
+    let index_ok = match &index_info {
+        Some(info) if info.age_hours <= threshold_index_age => true,
+        Some(info) => is_index_content_current(&cfg, &scan, &info.json),
+        None => false,
+    };
     let healthy = coverage_ok && orphans_ok && index_ok;
 
     let result = HealthCheckResult {

--- a/tests/cli_health_check.rs
+++ b/tests/cli_health_check.rs
@@ -293,6 +293,126 @@ fn health_check_unhealthy_stale_index() {
     assert!(json["index_age_hours"].as_f64().unwrap() > 24.0);
 }
 
+// -- Scenario: Stale timestamp but content identical — treated as healthy --
+
+#[test]
+fn health_check_stale_index_content_identical() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+
+    // 1 source file, tagged -> coverage 1.0
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+
+    // Matching specre card
+    write_specre_card(
+        tmp.path(),
+        "docs/specres/cli/card_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "card_a",
+        "stable",
+    );
+
+    // Generate real index.json with correct content
+    specre()
+        .args(["index"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Make the timestamp old (48 hours ago) but keep content identical
+    let index_path = tmp.path().join("docs/specres/index.json");
+    let content = fs::read_to_string(&index_path).unwrap();
+    let mut json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    json["generated_at"] = serde_json::Value::String(old_timestamp(48));
+    fs::write(&index_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+    let output = specre()
+        .args(["health-check"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "should be healthy when index content matches despite old timestamp"
+    );
+
+    let json = parse_json(&output.stdout);
+    assert_eq!(json["healthy"], true);
+    assert!(json["index_age_hours"].as_f64().unwrap() > 24.0);
+}
+
+// -- Scenario: Unhealthy ecosystem — index.json stale with content drift --
+
+#[test]
+fn health_check_stale_index_content_drift() {
+    let tmp = TempDir::new().unwrap();
+    write_config(tmp.path(), "docs/specres", &["src"]);
+
+    // 1 source file, tagged
+    write_source(
+        tmp.path(),
+        "src/a.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn a() {}\n",
+    );
+
+    write_specre_card(
+        tmp.path(),
+        "docs/specres/cli/card_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "card_a",
+        "stable",
+    );
+
+    // Generate real index.json
+    specre()
+        .args(["index"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Make the timestamp old
+    let index_path = tmp.path().join("docs/specres/index.json");
+    let content = fs::read_to_string(&index_path).unwrap();
+    let mut json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    json["generated_at"] = serde_json::Value::String(old_timestamp(48));
+    fs::write(&index_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+    // Now add a new source file and specre card (content drift)
+    write_source(
+        tmp.path(),
+        "src/b.rs",
+        "// @specre 01BBBBBBBBBBBBBBBBBBBBBBBB\nfn b() {}\n",
+    );
+
+    write_specre_card(
+        tmp.path(),
+        "docs/specres/cli/card_b.md",
+        "01BBBBBBBBBBBBBBBBBBBBBBBB",
+        "card_b",
+        "stable",
+    );
+
+    let output = specre()
+        .args(["health-check"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should be unhealthy when index content has drifted"
+    );
+
+    let json = parse_json(&output.stdout);
+    assert_eq!(json["healthy"], false);
+    assert!(json["index_age_hours"].as_f64().unwrap() > 24.0);
+}
+
 // -- Scenario: Custom thresholds via specre.toml --
 
 #[test]


### PR DESCRIPTION
## Summary

- Change index freshness evaluation in `health-check` from timestamp-only to a two-stage approach
- If `index_age_hours <= threshold`, treat index as fresh (unchanged behavior, fast path)
- If timestamp exceeds threshold, regenerate index data in memory and compare `specres` / `source_refs` against existing `index.json`
- If content is identical, treat as fresh (healthy=true); if content differs, treat as stale (healthy=false)
- Eliminates false negatives where the codebase hasn't changed but time has passed

## Test plan

- [x] `health_check_stale_index_content_identical` — old timestamp but identical content → healthy=true
- [x] `health_check_stale_index_content_drift` — old timestamp with content changes → healthy=false
- [x] All 14 existing tests pass (existing stale index test has content drift, so it remains unhealthy)
- [x] `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)