### PR TITLE
ci: skip CI for non-code changes and add branch protection gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - "**/*.rs"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - ".github/workflows/ci.yml"
+
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,6 +47,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +61,8 @@ jobs:
 
   fmt:
     name: Rustfmt
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,3 +71,19 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [test, clippy, fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" || \
+                "${{ needs.clippy.result }}" == "failure" || \
+                "${{ needs.fmt.result }}" == "failure" ]]; then
+            echo "CI failed"
+            exit 1
+          fi
+          echo "CI passed (jobs may have been skipped for non-code changes)"


### PR DESCRIPTION
## Summary
- Add `dorny/paths-filter` to detect code-relevant changes (`.rs`, `Cargo.toml`, `Cargo.lock`, `ci.yml`)
- Skip `test`, `clippy`, `fmt` jobs when only docs/markdown are changed, saving CI minutes
- Add `CI Gate` job that always runs and aggregates results — set as the sole required status check on `main`
- Configure branch protection on `main`: force push disabled, branch deletion disabled, `CI Gate` required (strict mode)

## Test plan
- [ ] Push a markdown-only change and verify test/clippy/fmt are skipped but CI Gate passes
- [ ] Push a code change and verify all jobs run normally
- [ ] Verify PR cannot be merged if CI Gate fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)