### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] - 2026-02-22
+
+### Fixed
+
+- `specre health-check`: use content comparison instead of timestamp for index freshness detection, eliminating false "stale index" warnings
+- Source scanner: exclude dot files (e.g. `.gitignore`) and SVG files from scanning, reducing noise in `trace`, `orphans`, `coverage`, and `index` results
+
+### Changed
+
+- CI: skip workflow runs for non-code changes (docs, markdown, config) and add branch protection gate job
+
 ## [0.3.1] - 2026-02-22
 
 ### Fixed
@@ -110,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bidirectional traceability via `@specre <ULID>` source markers
 - specre card format with YAML front-matter (`id`, `name`, `status`, `last_verified`)
 
+[0.3.2]: https://github.com/yoshiakist/specre/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/yoshiakist/specre/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/yoshiakist/specre/compare/v0.2.6...v0.3.0
 [0.2.6]: https://github.com/yoshiakist/specre/compare/v0.2.5...v0.2.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specre"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specre"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "Atomic, living specification cards for AI-agent-friendly development"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.3.1 to 0.3.2
- Update CHANGELOG.md with entries for health-check content comparison fix, dot file/SVG exclusion from scanner, and CI improvements

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (327 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)