### PR TITLE
feat: add exclude_patterns to filter files from source scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "assert_fs",
  "chrono",
  "clap",
+ "globset",
  "libc",
  "predicates",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ schemars = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_yml = "0.0.12"
+globset = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/docs/specres/cli/source_scanning_respects_exclude_patterns.md
+++ b/docs/specres/cli/source_scanning_respects_exclude_patterns.md
@@ -1,0 +1,93 @@
+---
+id: "01KJ4NJW28F072X64SS68P3N08"
+name: "source_scanning_respects_exclude_patterns"
+status: "in-development"
+---
+
+## Related Files
+
+- src/config.rs
+- src/scanner.rs
+- src/commands/init.rs
+- src/commands/coverage.rs
+- src/commands/orphans.rs
+- src/commands/health_check.rs
+- src/commands/index.rs
+- src/commands/trace.rs
+- src/commands/mcp/helpers.rs
+- tests/cli_coverage.rs
+- tests/cli_orphans.rs
+- tests/cli_trace.rs
+- tests/cli_health_check.rs
+- tests/cli_index.rs
+
+## Functional Overview
+
+Setting `exclude_patterns` (an array of glob patterns) in `specre.toml` excludes matching files and directories from source scanning. The exclusion applies to all commands that scan source files: `coverage`, `orphans`, `trace` (ULID mode), `index`, `health-check`, and the corresponding MCP handlers.
+
+Patterns are compiled into a single `GlobSet` via the `globset` crate and matched against forward-slash-normalized paths. Invalid patterns emit a warning to stderr and are skipped; processing continues with the remaining valid patterns.
+
+Exclusion acts as a filter during directory traversal (scanning). When a file path is specified explicitly — such as `specre trace <file-path>` — exclude patterns are not applied. This follows the same philosophy as `.gitignore` where `git show` still works on ignored files: filters apply to discovery, not to explicit references.
+
+## Scenarios
+
+### File glob excludes matching files from coverage
+
+1. Set `exclude_patterns = ["*.test.ts"]` in `specre.toml`
+2. `src/app.ts` (tagged) and `src/app.test.ts` (untagged) exist
+3. Run `specre coverage`
+4. Coverage is 1/1 (100%) — `.test.ts` files are excluded from the denominator
+
+### Directory pattern excludes entire subtree
+
+1. Set `exclude_patterns = ["*/_generated/*"]` in `specre.toml`
+2. `src/main.rs` (tagged), `src/_generated/schema.rs`, and `src/_generated/types.rs` (untagged) exist
+3. Run `specre coverage`
+4. Coverage is 1/1 (100%) — files under `_generated/` are excluded
+
+### Combined with target_extensions
+
+1. Set `target_extensions = ["ts"]` and `exclude_patterns = ["*.test.ts"]`
+2. `src/app.ts` (tagged), `src/util.ts` (untagged), `src/app.test.ts`, and `src/script.py` exist
+3. Run `specre coverage`
+4. `.py` is excluded by the extension filter, `.test.ts` is excluded by the pattern — coverage is 1/2 (50%)
+
+### Excluded files' dangling markers are not reported by orphans
+
+1. Set `exclude_patterns = ["*.test.ts"]`
+2. `src/app.test.ts` contains an `@specre` marker with a non-existent ULID
+3. Run `specre orphans`
+4. The marker is not reported as dangling
+
+### Excluded files' source refs are hidden from trace by ULID
+
+1. Set `exclude_patterns = ["*.test.ts"]`
+2. Both `src/main.rs` and `src/app.test.ts` contain an `@specre` marker with the same ULID
+3. Run `specre trace <ULID>`
+4. Only `src/main.rs` is shown; `src/app.test.ts` is hidden
+
+### Trace by file-path ignores exclude patterns
+
+1. Set `exclude_patterns = ["*.test.ts"]`
+2. `src/app.test.ts` contains `@specre` markers
+3. Run `specre trace src/app.test.ts`
+4. The marker ULIDs are displayed normally — explicit file references bypass exclusion
+
+### Excluded files' source refs are not in index.json
+
+1. Set `exclude_patterns = ["*.test.ts"]`
+2. Both `src/main.rs` and `src/app.test.ts` contain `@specre` markers
+3. Run `specre index`
+4. `index.json` `source_refs` includes only `src/main.rs`
+
+### Invalid pattern warns and continues
+
+1. Set `exclude_patterns = ["[invalid"]`
+2. Run `specre coverage`
+3. stderr shows `Warning: invalid exclude pattern`
+4. The command completes successfully; the invalid pattern is ignored
+
+### Backward compatibility: no exclude_patterns
+
+1. `specre.toml` has no `exclude_patterns` field
+2. All commands work as before (covered by existing tests)

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -54,8 +54,9 @@ pub fn coverage_from_scan_ref(scan: &SourceScanResult) -> CoverageResult {
 pub fn compute_coverage(
     source_dirs: &[String],
     target_extensions: Option<&[String]>,
+    exclude_patterns: Option<&[String]>,
 ) -> CoverageResult {
-    let scan = scan_source_markers(source_dirs, target_extensions);
+    let scan = scan_source_markers(source_dirs, target_extensions, exclude_patterns);
     coverage_from_scan(scan)
 }
 
@@ -67,7 +68,11 @@ pub fn execute(args: CoverageArgs, json: bool) -> Result<(), SpecreError> {
 
     let extensions = args.ext.or(config.target_extensions);
 
-    let result = compute_coverage(&config.source_dirs, extensions.as_deref());
+    let result = compute_coverage(
+        &config.source_dirs,
+        extensions.as_deref(),
+        config.exclude_patterns.as_deref(),
+    );
 
     let uncovered_total = result.uncovered.len();
     let is_truncated = uncovered_total > UNCOVERED_DISPLAY_LIMIT;

--- a/src/commands/health_check.rs
+++ b/src/commands/health_check.rs
@@ -115,7 +115,11 @@ pub fn execute() -> Result<(), SpecreError> {
     let threshold_index_age = hc.and_then(|h| h.index_age_hours).unwrap_or(24.0);
 
     // Single scan for both coverage and orphans
-    let scan = scan_source_markers(&cfg.source_dirs, cfg.target_extensions.as_deref());
+    let scan = scan_source_markers(
+        &cfg.source_dirs,
+        cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
+    );
 
     // Coverage
     let cov = coverage_from_scan_ref(&scan);

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -4,7 +4,7 @@ use crate::card::{self, SpecreCard, to_forward_slash};
 use crate::config;
 use crate::error::SpecreError;
 use crate::parser::extract_marker_ulid;
-use crate::scanner::collect_all_files;
+use crate::scanner::{collect_all_files, compile_exclude_patterns};
 use chrono::Utc;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -44,7 +44,11 @@ pub fn execute(json_flag: bool) -> Result<(), SpecreError> {
 
     let specre_dir = Path::new(&config.specre_dir);
     let specres = card::scan_specre_cards(specre_dir, &config.specre_dir);
-    let source_refs = scan_source_refs(&config.source_dirs, config.target_extensions.as_deref());
+    let source_refs = scan_source_refs(
+        &config.source_dirs,
+        config.target_extensions.as_deref(),
+        config.exclude_patterns.as_deref(),
+    );
 
     let index = Index {
         version: 1,
@@ -89,14 +93,16 @@ pub fn execute(json_flag: bool) -> Result<(), SpecreError> {
 fn scan_source_refs(
     source_dirs: &[String],
     target_extensions: Option<&[String]>,
+    exclude_patterns: Option<&[String]>,
 ) -> Vec<SourceRef> {
+    let exclude_set = compile_exclude_patterns(exclude_patterns);
     let mut refs = Vec::new();
     for dir_str in source_dirs {
         let dir = Path::new(dir_str);
         if !dir.exists() {
             continue;
         }
-        collect_all_files(dir, target_extensions, &mut |path| {
+        collect_all_files(dir, target_extensions, exclude_set.as_ref(), &mut |path| {
             let content = match fs::read_to_string(path) {
                 Ok(c) => c,
                 Err(e) => {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -15,6 +15,8 @@ struct SpecreConfig {
     language: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_extensions: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exclude_patterns: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -85,6 +87,7 @@ pub fn execute(args: InitArgs, json: bool) -> Result<(), SpecreError> {
         source_dirs,
         language,
         target_extensions: ext,
+        exclude_patterns: None,
     };
     let config_content = toml::to_string(&config).map_err(SpecreError::ConfigSerialize)?;
 

--- a/src/commands/mcp/helpers.rs
+++ b/src/commands/mcp/helpers.rs
@@ -190,7 +190,11 @@ pub fn execute_index() -> Result<CallToolResult, McpError> {
     let cfg = load_config()?;
     let specre_dir = Path::new(&cfg.specre_dir);
     let cards = card::scan_specre_cards(specre_dir, &cfg.specre_dir);
-    let scan = scan_source_markers(&cfg.source_dirs, cfg.target_extensions.as_deref());
+    let scan = scan_source_markers(
+        &cfg.source_dirs,
+        cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
+    );
 
     // Build source_refs array for index.json
     let source_refs: Vec<serde_json::Value> = scan
@@ -382,7 +386,11 @@ fn trace_by_ulid(ulid_str: &str) -> Result<CallToolResult, McpError> {
     let specre_path = cards.iter().find(|c| c.id == ulid_str).map(|c| &c.path);
 
     // Find source references
-    let scan = scan_source_markers(&cfg.source_dirs, cfg.target_extensions.as_deref());
+    let scan = scan_source_markers(
+        &cfg.source_dirs,
+        cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
+    );
     let source_refs: Vec<serde_json::Value> = scan
         .all_markers
         .iter()
@@ -460,6 +468,7 @@ pub fn execute_orphans() -> Result<CallToolResult, McpError> {
         &cfg.specre_dir,
         &cfg.source_dirs,
         cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
     );
 
     let json = serde_json::to_value(&result).map_err(|e| {
@@ -485,6 +494,7 @@ pub fn execute_coverage() -> Result<CallToolResult, McpError> {
     let cov = crate::commands::coverage::compute_coverage(
         &cfg.source_dirs,
         cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
     );
 
     let coverage_ratio = if cov.total == 0 {
@@ -530,7 +540,11 @@ pub fn execute_health_check() -> Result<CallToolResult, McpError> {
     let t_index_age = hc.and_then(|h| h.index_age_hours).unwrap_or(24.0);
 
     // Single scan for both coverage and orphans
-    let scan = scan_source_markers(&cfg.source_dirs, cfg.target_extensions.as_deref());
+    let scan = scan_source_markers(
+        &cfg.source_dirs,
+        cfg.target_extensions.as_deref(),
+        cfg.exclude_patterns.as_deref(),
+    );
 
     let cov = coverage_from_scan_ref(&scan);
     let coverage_ratio = if cov.total == 0 {

--- a/src/commands/orphans.rs
+++ b/src/commands/orphans.rs
@@ -122,8 +122,9 @@ pub fn compute_orphans(
     specre_dir: &str,
     source_dirs: &[String],
     target_extensions: Option<&[String]>,
+    exclude_patterns: Option<&[String]>,
 ) -> OrphanResult {
-    let scan = scan_source_markers(source_dirs, target_extensions);
+    let scan = scan_source_markers(source_dirs, target_extensions, exclude_patterns);
     orphans_from_scan(specre_dir, scan)
 }
 
@@ -137,6 +138,7 @@ pub fn execute(json: bool) -> Result<(), SpecreError> {
         &config.specre_dir,
         &config.source_dirs,
         config.target_extensions.as_deref(),
+        config.exclude_patterns.as_deref(),
     );
 
     if json {

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -5,7 +5,7 @@ use crate::cli::TraceArgs;
 use crate::config;
 use crate::error::SpecreError;
 use crate::parser::{extract_marker_ulid, parse_frontmatter};
-use crate::scanner::{collect_all_files, collect_md_files};
+use crate::scanner::{collect_all_files, collect_md_files, compile_exclude_patterns};
 use crate::ulid;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -76,29 +76,35 @@ fn trace_by_ulid(ulid: &str, json: bool) -> Result<(), SpecreError> {
     }
 
     // Find source references
+    let exclude_set = compile_exclude_patterns(config.exclude_patterns.as_deref());
     let mut source_refs: Vec<(Rc<str>, usize)> = Vec::new();
     for dir_str in &config.source_dirs {
         let dir = Path::new(dir_str);
         if !dir.exists() {
             continue;
         }
-        collect_all_files(dir, config.target_extensions.as_deref(), &mut |path| {
-            let content = match fs::read_to_string(path) {
-                Ok(c) => c,
-                Err(e) => {
-                    eprintln!("Warning: failed to read '{}': {e}", path.display());
-                    return;
+        collect_all_files(
+            dir,
+            config.target_extensions.as_deref(),
+            exclude_set.as_ref(),
+            &mut |path| {
+                let content = match fs::read_to_string(path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Warning: failed to read '{}': {e}", path.display());
+                        return;
+                    }
+                };
+                let rel_path: Rc<str> = Rc::from(to_forward_slash(path).as_ref());
+                for (line_num, line) in content.lines().enumerate() {
+                    if let Some(found_ulid) = extract_marker_ulid(line)
+                        && found_ulid == ulid
+                    {
+                        source_refs.push((Rc::clone(&rel_path), line_num + 1));
+                    }
                 }
-            };
-            let rel_path: Rc<str> = Rc::from(to_forward_slash(path).as_ref());
-            for (line_num, line) in content.lines().enumerate() {
-                if let Some(found_ulid) = extract_marker_ulid(line)
-                    && found_ulid == ulid
-                {
-                    source_refs.push((Rc::clone(&rel_path), line_num + 1));
-                }
-            }
-        });
+            },
+        );
     }
     source_refs.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub source_dirs: Vec<String>,
     pub language: Option<String>,
     pub target_extensions: Option<Vec<String>>,
+    pub exclude_patterns: Option<Vec<String>>,
     pub health_check: Option<HealthCheckConfig>,
     pub search: Option<SearchConfig>,
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -3,6 +3,7 @@
 // @specre 01KHFD5R1G3C5R34XMQXQTTMM9
 use crate::card::to_forward_slash;
 use crate::parser::extract_marker_ulid;
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -52,9 +53,40 @@ pub fn collect_md_files<F: FnMut(&Path)>(dir: &Path, cb: &mut F) {
 /// These are text files that pass UTF-8 decoding but are never source code.
 const EXCLUDED_EXTENSIONS: &[&str] = &["svg"];
 
+/// Compiles an optional list of glob patterns into a [`GlobSet`] for O(1) matching.
+///
+/// Invalid patterns are reported as warnings on stderr and skipped.
+#[must_use]
+pub fn compile_exclude_patterns(patterns: Option<&[String]>) -> Option<GlobSet> {
+    let patterns = patterns?;
+    if patterns.is_empty() {
+        return None;
+    }
+    let mut builder = GlobSetBuilder::new();
+    for pat in patterns {
+        match GlobBuilder::new(pat).literal_separator(false).build() {
+            Ok(glob) => {
+                builder.add(glob);
+            }
+            Err(e) => {
+                eprintln!("Warning: invalid exclude pattern '{pat}': {e}");
+            }
+        }
+    }
+    match builder.build() {
+        Ok(set) if !set.is_empty() => Some(set),
+        Ok(_) => None,
+        Err(e) => {
+            eprintln!("Warning: failed to compile exclude patterns: {e}");
+            None
+        }
+    }
+}
+
 pub fn collect_all_files<F: FnMut(&Path)>(
     dir: &Path,
     target_extensions: Option<&[String]>,
+    exclude_set: Option<&GlobSet>,
     cb: &mut F,
 ) {
     let read_dir = match fs::read_dir(dir) {
@@ -86,7 +118,14 @@ pub fn collect_all_files<F: FnMut(&Path)>(
             {
                 continue;
             }
-            collect_all_files(&path, target_extensions, cb);
+            // Check exclude patterns on directory before recursing
+            if let Some(excludes) = exclude_set {
+                let forward = to_forward_slash(&path);
+                if excludes.is_match(forward.as_ref()) {
+                    continue;
+                }
+            }
+            collect_all_files(&path, target_extensions, exclude_set, cb);
         } else {
             // Skip dot files (mirrors dot-directory exclusion above)
             if path
@@ -108,6 +147,13 @@ pub fn collect_all_files<F: FnMut(&Path)>(
                     .extension()
                     .is_some_and(|ext| exts.iter().any(|e| e == ext.to_string_lossy().as_ref()));
                 if !matches {
+                    continue;
+                }
+            }
+            // Check exclude patterns on file
+            if let Some(excludes) = exclude_set {
+                let forward = to_forward_slash(&path);
+                if excludes.is_match(forward.as_ref()) {
                     continue;
                 }
             }
@@ -145,7 +191,9 @@ pub struct MarkerLocation {
 pub fn scan_source_markers(
     source_dirs: &[String],
     target_extensions: Option<&[String]>,
+    exclude_patterns: Option<&[String]>,
 ) -> SourceScanResult {
+    let exclude_set = compile_exclude_patterns(exclude_patterns);
     let mut total = 0usize;
     let mut tagged = 0usize;
     let mut uncovered = Vec::new();
@@ -157,7 +205,7 @@ pub fn scan_source_markers(
         if !dir.exists() {
             continue;
         }
-        collect_all_files(dir, target_extensions, &mut |path| {
+        collect_all_files(dir, target_extensions, exclude_set.as_ref(), &mut |path| {
             let content = match fs::read_to_string(path) {
                 Ok(c) => c,
                 Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -37,6 +37,50 @@ fn write_config_with_ext(
     fs::write(dir.join("specre.toml"), content).unwrap();
 }
 
+fn write_config_with_exclude(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    exclude_patterns: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\nexclude_patterns = [{}]\n",
+        dirs_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
+fn write_config_with_ext_and_exclude(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    target_extensions: &[&str],
+    exclude_patterns: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let ext_toml: Vec<String> = target_extensions
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\ntarget_extensions = [{}]\nexclude_patterns = [{}]\n",
+        dirs_toml.join(", "),
+        ext_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
 fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
     let path = dir.join(rel_path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -522,4 +566,114 @@ fn coverage_excludes_svg_files() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: exclude_patterns excludes files from coverage --
+
+#[test]
+fn coverage_exclude_patterns_file_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["*.test.ts"]);
+    write_source(
+        tmp.path(),
+        "src/app.ts",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nconst x = 1;\n",
+    );
+    // This test file should be excluded from coverage
+    write_source(tmp.path(), "src/app.test.ts", "// no marker\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: exclude_patterns excludes directories --
+
+#[test]
+fn coverage_exclude_patterns_directory() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["*/_generated/*"]);
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // These generated files should be excluded
+    write_source(tmp.path(), "src/_generated/schema.rs", "struct S {}\n");
+    write_source(tmp.path(), "src/_generated/types.rs", "type T = i32;\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/1 files (100.0%)"));
+}
+
+// -- Scenario: target_extensions + exclude_patterns combined --
+
+#[test]
+fn coverage_target_extensions_and_exclude_patterns() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_ext_and_exclude(
+        tmp.path(),
+        "docs/specres",
+        &["src"],
+        &["ts"],
+        &["*.test.ts"],
+    );
+    write_source(
+        tmp.path(),
+        "src/app.ts",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nconst x = 1;\n",
+    );
+    write_source(tmp.path(), "src/util.ts", "export {};\n");
+    // test file — excluded by pattern
+    write_source(tmp.path(), "src/app.test.ts", "// test\n");
+    // py file — excluded by target_extensions
+    write_source(tmp.path(), "src/script.py", "# no marker\n");
+
+    specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Coverage: 1/2 files (50.0%)"));
+}
+
+// -- Scenario: invalid exclude pattern warns but continues --
+
+#[test]
+fn coverage_invalid_exclude_pattern_warns() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["[invalid"]);
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+
+    let output = specre()
+        .args(["coverage"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Warning: invalid exclude pattern"),
+        "Expected warning about invalid pattern in stderr, got: {stderr}"
+    );
+
+    // Coverage should still work (pattern is skipped)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Coverage: 1/1 files (100.0%)"),
+        "Coverage should still work, got: {stdout}"
+    );
 }

--- a/tests/cli_health_check.rs
+++ b/tests/cli_health_check.rs
@@ -34,6 +34,28 @@ fn write_config_with_health_check(
     fs::write(dir.join("specre.toml"), content).unwrap();
 }
 
+fn write_config_with_exclude_and_health_check(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    exclude_patterns: &[&str],
+    coverage: f64,
+    orphans: usize,
+    index_age_hours: f64,
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\nexclude_patterns = [{}]\n\n[health_check]\ncoverage = {coverage}\norphans = {orphans}\nindex_age_hours = {index_age_hours}\n",
+        dirs_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
 fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
     let path = dir.join(rel_path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -664,4 +686,56 @@ fn health_check_warns_on_unreadable_index_json() {
     assert!(json["index_age_hours"].is_null());
 
     fs::set_permissions(&index_path, fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+// -- Scenario: exclude_patterns makes coverage healthy --
+
+#[test]
+fn health_check_exclude_patterns_improves_coverage() {
+    let tmp = TempDir::new().unwrap();
+    // Without exclude, coverage would be 1/3 = 33% (below 0.90 threshold)
+    // With exclude, coverage becomes 1/1 = 100% (above threshold)
+    write_config_with_exclude_and_health_check(
+        tmp.path(),
+        "docs/specres",
+        &["src"],
+        &["*.test.ts", "*/_generated/*"],
+        0.90,
+        5,
+        24.0,
+    );
+
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // These should be excluded
+    write_source(tmp.path(), "src/app.test.ts", "// no marker\n");
+    write_source(tmp.path(), "src/_generated/types.rs", "type T = i32;\n");
+
+    write_specre_card(
+        tmp.path(),
+        "docs/specres/cli/card_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "card_a",
+        "stable",
+    );
+
+    write_index_json(tmp.path(), &recent_timestamp());
+
+    let output = specre()
+        .args(["health-check"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "should be healthy after excluding test/generated files"
+    );
+
+    let json = parse_json(&output.stdout);
+    assert_eq!(json["healthy"], true);
+    assert_eq!(json["coverage"], 1.0);
 }

--- a/tests/cli_index.rs
+++ b/tests/cli_index.rs
@@ -59,6 +59,26 @@ fn write_specre(
     fs::write(path, fm).unwrap();
 }
 
+/// Helper: create `specre.toml` with `exclude_patterns`
+fn write_config_with_exclude(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    exclude_patterns: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\nexclude_patterns = [{}]\n",
+        dirs_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
 /// Helper: create a source file with @specre markers
 fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
     let path = dir.join(rel_path);
@@ -942,4 +962,45 @@ fn index_warns_on_unreadable_source_file_permission() {
 
     // Restore permissions for cleanup
     fs::set_permissions(&bad_file, fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+// -- Scenario: exclude_patterns excludes files from index source_refs --
+
+#[test]
+fn index_exclude_patterns_hides_excluded_source_refs() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["*.test.ts"]);
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/my_spec.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "my_spec",
+        "draft",
+        None,
+    );
+    // Normal source file — should be in index
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // Test file — should be excluded from index
+    write_source(
+        tmp.path(),
+        "src/app.test.ts",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n",
+    );
+
+    specre()
+        .args(["index"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let json_str = fs::read_to_string(tmp.path().join("docs/specres/index.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    let refs = json["source_refs"].as_array().unwrap();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0]["file"], "src/main.rs");
 }

--- a/tests/cli_orphans.rs
+++ b/tests/cli_orphans.rs
@@ -46,6 +46,25 @@ fn write_specre(dir: &std::path::Path, rel_path: &str, id: &str, name: &str, sta
     fs::write(path, fm).unwrap();
 }
 
+fn write_config_with_exclude(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    exclude_patterns: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\nexclude_patterns = [{}]\n",
+        dirs_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
 fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
     let path = dir.join(rel_path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -505,4 +524,29 @@ fn orphans_warns_on_unreadable_source_file() {
     );
 
     fs::set_permissions(&bad_file, fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+// -- Scenario: exclude_patterns hides dangling markers in excluded files --
+
+#[test]
+fn orphans_exclude_patterns_hides_dangling_in_excluded_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["*.test.ts"]);
+    fs::create_dir_all(tmp.path().join("docs/specres")).unwrap();
+    // Dangling marker in excluded test file — should NOT be reported
+    write_source(
+        tmp.path(),
+        "src/app.test.ts",
+        "// @specre 01ZZZZZZZZZZZZZZZZZZZZZZZZ\n",
+    );
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    specre()
+        .args(["orphans"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No orphans or dangling markers found.",
+        ));
 }

--- a/tests/cli_trace.rs
+++ b/tests/cli_trace.rs
@@ -46,6 +46,25 @@ fn write_specre(dir: &std::path::Path, rel_path: &str, id: &str, name: &str, sta
     fs::write(path, fm).unwrap();
 }
 
+fn write_config_with_exclude(
+    dir: &std::path::Path,
+    specre_dir: &str,
+    source_dirs: &[&str],
+    exclude_patterns: &[&str],
+) {
+    let dirs_toml: Vec<String> = source_dirs.iter().map(|s| format!("\"{s}\"")).collect();
+    let pats_toml: Vec<String> = exclude_patterns
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect();
+    let content = format!(
+        "specre_dir = \"{specre_dir}\"\nsource_dirs = [{}]\nexclude_patterns = [{}]\n",
+        dirs_toml.join(", "),
+        pats_toml.join(", ")
+    );
+    fs::write(dir.join("specre.toml"), content).unwrap();
+}
+
 fn write_source(dir: &std::path::Path, rel_path: &str, content: &str) {
     let path = dir.join(rel_path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -675,4 +694,41 @@ fn trace_ulid_warns_on_unreadable_source_file() {
     assert!(stdout.contains("src/good.rs"));
 
     fs::set_permissions(&bad_file, fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+// -- Scenario: exclude_patterns hides source refs in excluded files --
+
+#[test]
+fn trace_ulid_exclude_patterns_hides_excluded_files() {
+    let tmp = TempDir::new().unwrap();
+    write_config_with_exclude(tmp.path(), "docs/specres", &["src"], &["*.test.ts"]);
+    write_specre(
+        tmp.path(),
+        "docs/specres/cli/spec_a.md",
+        "01AAAAAAAAAAAAAAAAAAAAAAAA",
+        "spec_a",
+        "stable",
+    );
+    // Source ref in a non-excluded file
+    write_source(
+        tmp.path(),
+        "src/main.rs",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\nfn main() {}\n",
+    );
+    // Source ref in an excluded test file — should NOT appear
+    write_source(
+        tmp.path(),
+        "src/app.test.ts",
+        "// @specre 01AAAAAAAAAAAAAAAAAAAAAAAA\n",
+    );
+
+    specre()
+        .args(["trace", "01AAAAAAAAAAAAAAAAAAAAAAAA"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("src/main.rs:1")
+                .and(predicate::str::contains("app.test.ts").not()),
+        );
 }


### PR DESCRIPTION
## Summary

- Add `exclude_patterns` (glob pattern array) to `specre.toml` to exclude files/directories from source scanning
- Applied to all commands: `coverage`, `orphans`, `trace` (ULID mode), `index`, `health-check`, and MCP handlers
- Explicit file-path references (`specre trace <file-path>`) bypass exclusion — same philosophy as `.gitignore` vs `git show`

## Changes

- Add `globset` crate dependency (`default-features = false`)
- Add `exclude_patterns: Option<Vec<String>>` field to `Config`
- Add `compile_exclude_patterns()` helper and exclude filter to `collect_all_files` in `scanner.rs`
- Update all command and MCP handler call sites
- Add 8 integration tests (coverage x4, orphans x1, trace x1, health-check x1, index x1)
- Create specre card

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all tests pass

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)